### PR TITLE
feat: moved connection methods to core and deprecated existing ones

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -3,8 +3,8 @@ package e_cmd
 
 import (
 	"fmt"
-	e_connection "github.com/elcengine/elemental/connection"
-	e_utils "github.com/elcengine/elemental/utils"
+	"github.com/elcengine/elemental/core"
+	"github.com/elcengine/elemental/utils"
 	"log"
 	"os"
 	"os/exec"
@@ -54,7 +54,7 @@ import (
 	"time"
 	"go.mongodb.org/mongo-driver/mongo"
 	"github.com/samber/lo"
-	"github.com/elcengine/elemental/connection"
+	"github.com/elcengine/elemental/core"
 	"github.com/elcengine/elemental/database/%ss"
 )
 
@@ -66,8 +66,8 @@ import (
 }
 
 func main() {
-	client := e_connection.ConnectURI("%s")
-	db := e_connection.UseDefault()
+	client := elemental.Connect("%s")
+	db := elemental.UseDefaultDatabase()
 	go db.Collection("%s").Indexes().CreateOne(context.Background(), mongo.IndexModel{
 		Keys: map[string]interface{}{"type": 1},
 	})
@@ -111,13 +111,13 @@ func main() {
 		target,
 		rollback, cfg.ChangelogCollection, cfg.ChangelogCollection, target,
 	)
-	e_connection.ConnectURI(cfg.ConnectionStr)
-	defer e_connection.Disconnect()
+	elemental.Connect(cfg.ConnectionStr)
+	defer elemental.Disconnect()
 	os.MkdirAll(".elemental/"+target+"s", os.ModePerm)
 	e_utils.CreateAndWriteToFile(fmt.Sprintf(".elemental/%ss/main.go", target), template)
 	err = exec.Command("go", "run", ".elemental/"+target+"s/main.go").Run()
 	if err != nil {
-		e_connection.Disconnect()
+		elemental.Disconnect()
 		log.Fatalf("Failed to run %ss: %s", target, err.Error())
 	} else {
 		if rollback {

--- a/connection/events.go
+++ b/connection/events.go
@@ -1,76 +1,13 @@
 package e_connection
 
-import "go.mongodb.org/mongo-driver/event"
-
-var eventListeners = make(map[string]map[string]func())
-
-func triggerEventIfRegistered(alias, eventType string) {
-	if eventListeners[alias][eventType] != nil {
-		eventListeners[alias][eventType]()
-	}
-}
-
-func poolMonitor(alias string) *event.PoolMonitor {
-	poolMonitor := &event.PoolMonitor{
-		Event: func(evt *event.PoolEvent) {
-			if eventListeners[alias] != nil {
-				switch evt.Type {
-				case event.ConnectionClosed:
-					triggerEventIfRegistered(alias, event.ConnectionClosed)
-				case event.ConnectionCreated:
-					triggerEventIfRegistered(alias, event.ConnectionCreated)
-				case event.ConnectionReady:
-					triggerEventIfRegistered(alias, event.ConnectionReady)
-				case event.ConnectionReturned:
-					triggerEventIfRegistered(alias, event.ConnectionReturned)
-				case event.GetFailed:
-					triggerEventIfRegistered(alias, event.GetFailed)
-				case event.GetStarted:
-					triggerEventIfRegistered(alias, event.GetStarted)
-				case event.GetSucceeded:
-					triggerEventIfRegistered(alias, event.GetSucceeded)
-				case event.PoolCleared:
-					triggerEventIfRegistered(alias, event.PoolCleared)
-				case event.PoolClosedEvent:
-					triggerEventIfRegistered(alias, event.PoolClosedEvent)
-				case event.PoolCreated:
-					triggerEventIfRegistered(alias, event.PoolCreated)
-				case event.PoolReady:
-					triggerEventIfRegistered(alias, event.PoolReady)
-				}
-			}
-		},
-	}
-	return poolMonitor
-}
+import elemental "github.com/elcengine/elemental/core"
 
 // Add a listener to a connection
 //
-// @param event - The event to listen for
-//
-// @param handler - The function to call when the event is triggered
-//
-// @param alias - The alias of the connection to listen to
-func On(event string, handler func(), alias ...string) {
-	if len(alias) == 0 {
-		alias = []string{"default"}
-	}
-	if eventListeners[alias[0]] == nil {
-		eventListeners[alias[0]] = make(map[string]func())
-	}
-	eventListeners[alias[0]][event] = handler
-}
+// Deprecated: Use elemental.OnConnectionEvent instead.
+var On = elemental.OnConnectionEvent
 
 // Remove a listener from a connection
 //
-// @param event - The event to remove the listener from
-//
-// @param alias - The alias of the connection to remove the listener from
-func Off(event string, alias ...string) {
-	if len(alias) == 0 {
-		alias = []string{"default"}
-	}
-	if eventListeners[alias[0]] != nil {
-		eventListeners[alias[0]][event] = nil
-	}
-}
+// Deprecated: Use elemental.RemoveConnectionEvent instead.
+var Off = elemental.RemoveConnectionEvent

--- a/constants/errors.go
+++ b/constants/errors.go
@@ -1,6 +1,7 @@
 package e_constants
 
 const (
-	ErrURIRequired           = "URI is required"
-	ErrMustPairSortArguments = "Sort arguments must be in pairs"
+	ErrURIRequired               = "URI is required"
+	ErrInvalidConnectionArgument = "Invalid connection argument"
+	ErrMustPairSortArguments     = "Sort arguments must be in pairs"
 )

--- a/core/connection.go
+++ b/core/connection.go
@@ -99,6 +99,9 @@ var GetClient = GetConnection
 //
 // @param aliases - The aliases of the connections to disconnect
 func Disconnect(aliases ...string) error {
+	mu.Lock()
+	defer mu.Unlock()
+
 	if len(aliases) == 0 {
 		aliases = slices.AppendSeq(aliases, maps.Keys(clients))
 	}

--- a/core/connection_events.go
+++ b/core/connection_events.go
@@ -1,0 +1,76 @@
+package elemental
+
+import "go.mongodb.org/mongo-driver/event"
+
+var eventListeners = make(map[string]map[string]func())
+
+func triggerEventIfRegistered(alias, eventType string) {
+	if eventListeners[alias][eventType] != nil {
+		eventListeners[alias][eventType]()
+	}
+}
+
+func defaultPoolMonitor(alias string) *event.PoolMonitor {
+	poolMonitor := &event.PoolMonitor{
+		Event: func(evt *event.PoolEvent) {
+			if eventListeners[alias] != nil {
+				switch evt.Type {
+				case event.ConnectionClosed:
+					triggerEventIfRegistered(alias, event.ConnectionClosed)
+				case event.ConnectionCreated:
+					triggerEventIfRegistered(alias, event.ConnectionCreated)
+				case event.ConnectionReady:
+					triggerEventIfRegistered(alias, event.ConnectionReady)
+				case event.ConnectionReturned:
+					triggerEventIfRegistered(alias, event.ConnectionReturned)
+				case event.GetFailed:
+					triggerEventIfRegistered(alias, event.GetFailed)
+				case event.GetStarted:
+					triggerEventIfRegistered(alias, event.GetStarted)
+				case event.GetSucceeded:
+					triggerEventIfRegistered(alias, event.GetSucceeded)
+				case event.PoolCleared:
+					triggerEventIfRegistered(alias, event.PoolCleared)
+				case event.PoolClosedEvent:
+					triggerEventIfRegistered(alias, event.PoolClosedEvent)
+				case event.PoolCreated:
+					triggerEventIfRegistered(alias, event.PoolCreated)
+				case event.PoolReady:
+					triggerEventIfRegistered(alias, event.PoolReady)
+				}
+			}
+		},
+	}
+	return poolMonitor
+}
+
+// Add a listener to a connection event
+//
+// @param event - The event to listen for
+//
+// @param handler - The function to call when the event is triggered
+//
+// @param alias - The alias of the connection to listen to
+func OnConnectionEvent(event string, handler func(), alias ...string) {
+	if len(alias) == 0 {
+		alias = []string{"default"}
+	}
+	if eventListeners[alias[0]] == nil {
+		eventListeners[alias[0]] = make(map[string]func())
+	}
+	eventListeners[alias[0]][event] = handler
+}
+
+// Remove a listener from a connection event
+//
+// @param event - The event to remove the listener from
+//
+// @param alias - The alias of the connection to remove the listener from
+func RemoveConnectionEvent(event string, alias ...string) {
+	if len(alias) == 0 {
+		alias = []string{"default"}
+	}
+	if eventListeners[alias[0]] != nil {
+		eventListeners[alias[0]][event] = nil
+	}
+}

--- a/core/model.go
+++ b/core/model.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"strings"
 
-	e_connection "github.com/elcengine/elemental/connection"
 	e_constants "github.com/elcengine/elemental/constants"
 	e_utils "github.com/elcengine/elemental/utils"
 
@@ -67,7 +66,7 @@ func NewModel[T any](name string, schema Schema) Model[T] {
 		}
 	}
 	if model.Ping() != nil {
-		e_connection.On(event.ConnectionReady, connectionReady)
+		OnConnectionEvent(event.ConnectionReady, connectionReady)
 	} else {
 		connectionReady()
 	}

--- a/core/model_actions.go
+++ b/core/model_actions.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/elcengine/elemental/connection"
-	"github.com/elcengine/elemental/utils"
+	e_utils "github.com/elcengine/elemental/utils"
 	"github.com/samber/lo"
 
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
 func (m Model[T]) CreateCollection(ctx ...context.Context) *mongo.Collection {
-	e_connection.Use(m.Schema.Options.Database, m.Schema.Options.Connection).
+	UseDatabase(m.Schema.Options.Database, m.Schema.Options.Connection).
 		CreateCollection(e_utils.DefaultCTX(ctx), m.Schema.Options.Collection, &m.Schema.Options.CollectionOptions)
 	return m.Collection()
 }

--- a/core/model_meta.go
+++ b/core/model_meta.go
@@ -3,8 +3,7 @@ package elemental
 import (
 	"context"
 
-	"github.com/elcengine/elemental/connection"
-	"github.com/elcengine/elemental/utils"
+	e_utils "github.com/elcengine/elemental/utils"
 
 	"github.com/samber/lo"
 	"go.mongodb.org/mongo-driver/bson"
@@ -16,12 +15,12 @@ func (m Model[T]) Collection() *mongo.Collection {
 	connection := lo.FromPtr(e_utils.Coalesce(m.temporaryConnection, &m.Schema.Options.Connection))
 	database := lo.FromPtr(e_utils.Coalesce(m.temporaryDatabase, &m.Schema.Options.Database))
 	collection := lo.FromPtr(e_utils.Coalesce(m.temporaryCollection, &m.Schema.Options.Collection))
-	return e_connection.Use(database, connection).Collection(collection)
+	return UseDatabase(database, connection).Collection(collection)
 }
 
 // Returns the underlying client instance this model uses
 func (m Model[T]) Connection() mongo.Client {
-	return e_connection.GetConnection(lo.FromPtr(e_utils.Coalesce(m.temporaryConnection, &m.Schema.Options.Connection)))
+	return GetConnection(lo.FromPtr(e_utils.Coalesce(m.temporaryConnection, &m.Schema.Options.Connection)))
 }
 
 // Returns the underlying database instance this model uses

--- a/core/schema.go
+++ b/core/schema.go
@@ -5,8 +5,7 @@ import (
 	"reflect"
 
 	"github.com/creasty/defaults"
-	"github.com/elcengine/elemental/connection"
-	"github.com/elcengine/elemental/utils"
+	e_utils "github.com/elcengine/elemental/utils"
 	"github.com/samber/lo"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -43,7 +42,7 @@ func (s Schema) syncIndexes(reflectedBaseType reflect.Type, databaseOverride, co
 	database, _ := lo.Coalesce(databaseOverride, s.Options.Database)
 	connection, _ := lo.Coalesce(connectionOverride, s.Options.Connection)
 	collectionName, _ := lo.Coalesce(collectionOverride, s.Options.Collection)
-	collection := e_connection.Use(database, connection).Collection(collectionName)
+	collection := UseDatabase(database, connection).Collection(collectionName)
 	collection.Indexes().DropAll(context.Background())
 	for field, definition := range s.Definitions {
 		if (definition.Index != options.IndexOptions{}) {

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -2,14 +2,12 @@ package elemental
 
 import (
 	"context"
-
-	"github.com/elcengine/elemental/connection"
 	"github.com/samber/lo"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
 func transaction(fn func(ctx mongo.SessionContext) (interface{}, error), alias *string) (interface{}, error) {
-	session, err := lo.ToPtr(e_connection.GetConnection(lo.FromPtr(alias))).StartSession()
+	session, err := lo.ToPtr(GetConnection(lo.FromPtr(alias))).StartSession()
 	if err != nil {
 		panic(err)
 	}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -3,8 +3,9 @@ package e_repository
 import (
 	"context"
 	"errors"
-	"github.com/elcengine/elemental/connection"
 	"log"
+
+	elemental "github.com/elcengine/elemental/core"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -19,7 +20,7 @@ func NewRepository[T any](collection string) Repository[T] {
 }
 
 func (r Repository[T]) Create(payload T) primitive.ObjectID {
-	result, err := e_connection.UseDefault().Collection(r.collection).InsertOne(context.TODO(), payload)
+	result, err := elemental.UseDefaultDatabase().Collection(r.collection).InsertOne(context.TODO(), payload)
 	if err != nil {
 		panic(err)
 	}
@@ -28,7 +29,7 @@ func (r Repository[T]) Create(payload T) primitive.ObjectID {
 
 func (r Repository[T]) FindOne(query primitive.M) *T {
 	model := new(T)
-	doc := e_connection.UseDefault().Collection(r.collection).FindOne(context.Background(), query)
+	doc := elemental.UseDefaultDatabase().Collection(r.collection).FindOne(context.Background(), query)
 	if doc.Err() != nil {
 		if errors.Is(doc.Err(), mongo.ErrNoDocuments) {
 			log.Fatalf("%v %s", r, doc.Err().Error())
@@ -46,7 +47,7 @@ func (r Repository[T]) FindByID(id primitive.ObjectID) *T {
 
 func (r Repository[T]) FindAll() []T {
 	var users []T
-	cursor, err := e_connection.UseDefault().Collection(r.collection).Find(context.Background(), primitive.M{})
+	cursor, err := elemental.UseDefaultDatabase().Collection(r.collection).Find(context.Background(), primitive.M{})
 	if err != nil {
 		panic(err)
 	}
@@ -55,14 +56,14 @@ func (r Repository[T]) FindAll() []T {
 }
 
 func (r Repository[T]) Update(id primitive.ObjectID, payload T) {
-	_, err := e_connection.UseDefault().Collection(r.collection).UpdateOne(context.Background(), primitive.M{"_id": id}, primitive.M{"$set": payload})
+	_, err := elemental.UseDefaultDatabase().Collection(r.collection).UpdateOne(context.Background(), primitive.M{"_id": id}, primitive.M{"$set": payload})
 	if err != nil {
 		panic(err)
 	}
 }
 
 func (r Repository[T]) Delete(id primitive.ObjectID) {
-	_, err := e_connection.UseDefault().Collection(r.collection).DeleteOne(context.Background(), primitive.M{"_id": id})
+	_, err := elemental.UseDefaultDatabase().Collection(r.collection).DeleteOne(context.Background(), primitive.M{"_id": id})
 	if err != nil {
 		panic(err)
 	}

--- a/tests/connection_test.go
+++ b/tests/connection_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	e_connection "github.com/elcengine/elemental/connection"
 	e_constants "github.com/elcengine/elemental/constants"
+	elemental "github.com/elcengine/elemental/core"
 	e_mocks "github.com/elcengine/elemental/tests/mocks"
 	. "github.com/smartystreets/goconvey/convey"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -15,29 +15,32 @@ import (
 func TestConnection(t *testing.T) {
 	Convey("Connect to a local database", t, func() {
 		Convey("Simplest form of connect with just a URI", func() {
-			client := e_connection.Connect(e_connection.ConnectionOptions{
-				URI: strings.Replace(e_mocks.DEFAULT_DATASOURCE, e_mocks.DEFAULT_DB_NAME, t.Name(), 1),
-			})
+			client := elemental.Connect(strings.Replace(e_mocks.DEFAULT_DATASOURCE, e_mocks.DEFAULT_DB_NAME, t.Name(), 1))
 			So(client, ShouldNotBeNil)
 			Convey("Should use the default database", func() {
-				So(e_connection.UseDefault().Name(), ShouldEqual, t.Name())
+				So(elemental.UseDefaultDatabase().Name(), ShouldEqual, t.Name())
 			})
 			Convey("Should use the specified database", func() {
 				DATABASE := fmt.Sprintf("%s_%s", t.Name(), "secondary")
-				So(e_connection.Use(DATABASE).Name(), ShouldEqual, DATABASE)
+				So(elemental.UseDatabase(DATABASE).Name(), ShouldEqual, DATABASE)
 			})
 		})
 		Convey("Connect with a URI specified within client options", func() {
 			opts := options.Client().ApplyURI(strings.Replace(e_mocks.DEFAULT_DATASOURCE, e_mocks.DEFAULT_DB_NAME, t.Name(), 1))
-			client := e_connection.Connect(e_connection.ConnectionOptions{
+			client := elemental.Connect(elemental.ConnectionOptions{
 				ClientOptions: opts,
 			})
 			So(client, ShouldNotBeNil)
 		})
 		Convey("Connect with no URI", func() {
 			So(func() {
-				e_connection.Connect(e_connection.ConnectionOptions{})
+				elemental.Connect(elemental.ConnectionOptions{})
 			}, ShouldPanicWith, e_constants.ErrURIRequired)
+		})
+		Convey("Connect with invalid argument", func() {
+			So(func() {
+				elemental.Connect(123)
+			}, ShouldPanicWith, e_constants.ErrInvalidConnectionArgument)
 		})
 	})
 }

--- a/tests/core_create_test.go
+++ b/tests/core_create_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elcengine/elemental/connection"
-	"github.com/elcengine/elemental/tests/base"
-	"github.com/elcengine/elemental/tests/mocks"
-	"github.com/elcengine/elemental/tests/setup"
+	elemental "github.com/elcengine/elemental/core"
+	e_test_base "github.com/elcengine/elemental/tests/base"
+	e_mocks "github.com/elcengine/elemental/tests/mocks"
+	e_test_setup "github.com/elcengine/elemental/tests/setup"
 
 	. "github.com/smartystreets/goconvey/convey"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -47,7 +47,7 @@ func TestCoreCreate(t *testing.T) {
 			user := UserModel.Create(e_mocks.Ciri).SetDatabase(TEMPORARY_DB).Exec().(User)
 			So(user.ID, ShouldNotBeNil)
 			var newUser User
-			e_connection.Use(TEMPORARY_DB).Collection(UserModel.Collection().Name()).FindOne(context.TODO(), primitive.M{"_id": user.ID}).Decode(&newUser)
+			elemental.UseDatabase(TEMPORARY_DB).Collection(UserModel.Collection().Name()).FindOne(context.TODO(), primitive.M{"_id": user.ID}).Decode(&newUser)
 			So(newUser.Name, ShouldEqual, e_mocks.Ciri.Name)
 		})
 		Convey("Create a single user in a different collection in a different database", func() {
@@ -55,7 +55,7 @@ func TestCoreCreate(t *testing.T) {
 			user := UserModel.Create(e_mocks.Geralt).SetDatabase(TEMPORARY_DB).SetCollection("witchers").Exec().(User)
 			So(user.ID, ShouldNotBeNil)
 			var newUser User
-			e_connection.Use(TEMPORARY_DB).Collection("witchers").FindOne(context.TODO(), primitive.M{"_id": user.ID}).Decode(&newUser)
+			elemental.UseDatabase(TEMPORARY_DB).Collection("witchers").FindOne(context.TODO(), primitive.M{"_id": user.ID}).Decode(&newUser)
 			So(newUser.Name, ShouldEqual, e_mocks.Geralt.Name)
 		})
 	})

--- a/tests/multi_connection_test.go
+++ b/tests/multi_connection_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	e_connection "github.com/elcengine/elemental/connection"
+	elemental "github.com/elcengine/elemental/core"
 	e_mocks "github.com/elcengine/elemental/tests/mocks"
 	e_test_setup "github.com/elcengine/elemental/tests/setup"
 
@@ -20,7 +20,7 @@ func TestMultiConnection(t *testing.T) {
 
 	e_test_setup.Connection(t.Name())
 
-	e_connection.Connect(e_connection.ConnectionOptions{
+	elemental.Connect(elemental.ConnectionOptions{
 		URI:   e_mocks.SECONDARY_DATASOURCE,
 		Alias: "second",
 	})

--- a/tests/setup/setup.go
+++ b/tests/setup/setup.go
@@ -3,13 +3,13 @@ package e_test_setup
 import (
 	"strings"
 
-	e_connection "github.com/elcengine/elemental/connection"
+	elemental "github.com/elcengine/elemental/core"
 	e_test_base "github.com/elcengine/elemental/tests/base"
 	e_mocks "github.com/elcengine/elemental/tests/mocks"
 )
 
 func Connection(databaseName string) {
-	e_connection.ConnectURI(strings.Replace(e_mocks.DEFAULT_DATASOURCE, e_mocks.DEFAULT_DB_NAME, databaseName, 1))
+	elemental.Connect(strings.Replace(e_mocks.DEFAULT_DATASOURCE, e_mocks.DEFAULT_DB_NAME, databaseName, 1))
 }
 
 func Seed(databaseName string) {
@@ -22,6 +22,6 @@ func SeededConnection(databaseName string) {
 }
 
 func Teardown() {
-	e_connection.DropAll()
-	e_connection.Disconnect()
+	elemental.DropAllDatabases()
+	elemental.Disconnect()
 }


### PR DESCRIPTION
## Summary by Sourcery

Move and centralize all connection methods into the new core package, deprecate the old connection package functions, and migrate all code and tests to use the consolidated API.

New Features:
- Add new unified elemental.Connect API that accepts either a connection string or ConnectionOptions struct
- Introduce ErrInvalidConnectionArgument constant for invalid Connect arguments

Enhancements:
- Deprecate existing connection package methods and alias them to the new core implementations
- Update repository, CLI, schema, model, and transaction code to use core connection functions
- Migrate tests to reference elemental/core instead of elemental/connection

Tests:
- Add test case verifying Connect panics on invalid argument type