### PR TITLE
test: added cmd init test

### DIFF
--- a/.elementalrc
+++ b/.elementalrc
@@ -1,6 +1,6 @@
 {
-    "connection_str": "mongodb+srv://akalankaperera128:pFAnQVXE6vrbcXNk@default.ynr156r.mongodb.net/elemental",
-    "migrations_dir": "database/migrations",
-    "seeds_dir": "database/seeds",
-    "changelog_collection": "changelog"
+  "connection_str": "mongodb+srv://akalankaperera128:pFAnQVXE6vrbcXNk@default.ynr156r.mongodb.net/elemental",
+  "migrations_dir": "database/migrations",
+  "seeds_dir": "database/seeds",
+  "changelog_collection": "changelog"
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -3,33 +3,39 @@ package e_cmd
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/spf13/cobra"
 	"log"
 	"os"
+
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
 )
+
+const DefaultConfigFile = ".elementalrc"
 
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize elemental with a config file",
 	Run: func(cmd *cobra.Command, args []string) {
-		configFile := ".elementalrc"
-		_, err := os.Stat(configFile)
+
+		_, err := os.Stat(DefaultConfigFile)
 		if err == nil {
 			return
 		}
 		if !os.IsNotExist(err) {
 			log.Fatal(err)
 		}
-		f, err := os.Create(configFile)
+		f, err := os.Create(DefaultConfigFile)
 		if err != nil {
 			log.Fatal(err)
 		}
 		defer f.Close()
-		bytes, err := json.MarshalIndent(configWithDefaults(&config{}), "", "  ")
+		bytes, err := json.MarshalIndent(configWithDefaults(&Config{
+			ConnectionStr: lo.FirstOrEmpty(args),
+		}), "", "  ")
 		if err != nil {
 			log.Fatal(err)
 		}
 		f.Write(bytes)
-		fmt.Println("\033[32mElemental config file created at", configFile, "\033[0m")
+		fmt.Println("\033[32mElemental config file created at", DefaultConfigFile, "\033[0m")
 	},
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -16,7 +16,6 @@ var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize elemental with a config file",
 	Run: func(cmd *cobra.Command, args []string) {
-
 		_, err := os.Stat(DefaultConfigFile)
 		if err == nil {
 			return
@@ -35,7 +34,10 @@ var initCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		f.Write(bytes)
+		_, err = f.Write(bytes)
+		if err != nil {
+			log.Fatal(err)
+		}
 		fmt.Println("\033[32mElemental config file created at", DefaultConfigFile, "\033[0m")
 	},
 }

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -53,7 +53,6 @@ import (
 	"strconv"
 	"time"
 	"go.mongodb.org/mongo-driver/mongo"
-	"github.com/samber/lo"
 	"github.com/elcengine/elemental/core"
 	"github.com/elcengine/elemental/database/%ss"
 )
@@ -62,7 +61,11 @@ import (
 		fileName = strings.TrimSuffix(fileName, ".go")
 		parts := strings.Split(fileName, "_")
 		timestampStr := parts[len(parts)-1]
-		return lo.Must(strconv.ParseInt(timestampStr, 10, 64))
+		timestamp, err := strconv.ParseInt(timestampStr, 10, 64)
+		if err != nil {
+			panic(err)
+		}
+		return timestamp
 }
 
 func main() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,14 +12,14 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-type config struct {
-	ConnectionStr       string `json:"connection_str" yaml:"connection_str"`
-	MigrationsDir       string `json:"migrations_dir" yaml:"migrations_dir"`
-	SeedsDir            string `json:"seeds_dir" yaml:"seeds_dir"`
-	ChangelogCollection string `json:"changelog_collection" yaml:"changelog_collection"`
+type Config struct {
+	ConnectionStr       string `json:"connection_str" yaml:"connection_str"`             // The connection string to connect with the data source
+	MigrationsDir       string `json:"migrations_dir" yaml:"migrations_dir"`             // The directory where migration files are stored
+	SeedsDir            string `json:"seeds_dir" yaml:"seeds_dir"`                       // The directory where seed files are stored
+	ChangelogCollection string `json:"changelog_collection" yaml:"changelog_collection"` // The collection where changelogs are stored in the database
 }
 
-var rootCmd = &cobra.Command{
+var RootCmd = &cobra.Command{
 	Use:   "elemental",
 	Short: "Your next gen MongoDB ODM",
 	Long:  `Elemental is a user database ODM that allows you to interact with your database in a much more user friendly way than standard database drivers`,
@@ -39,19 +39,19 @@ If you encounter any issues, please report them at "https://github.com/go-elemen
 }
 
 func init() {
-	rootCmd.AddCommand(initCmd)
-	rootCmd.AddCommand(migrateCmd)
-	rootCmd.AddCommand(seedCmd)
+	RootCmd.AddCommand(initCmd)
+	RootCmd.AddCommand(migrateCmd)
+	RootCmd.AddCommand(seedCmd)
 }
 
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	if err := RootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }
 
-func configWithDefaults(conf *config) config {
+func configWithDefaults(conf *Config) Config {
 	if conf.MigrationsDir == "" {
 		conf.MigrationsDir = "database/migrations"
 	}
@@ -64,8 +64,8 @@ func configWithDefaults(conf *config) config {
 	return *conf
 }
 
-func readConfigFile() config {
-	var conf *config
+func readConfigFile() Config {
+	var conf *Config
 
 	dir, err := os.Getwd()
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,7 +65,7 @@ func configWithDefaults(conf *Config) Config {
 }
 
 func readConfigFile() Config {
-	var conf *Config
+	var conf Config
 
 	dir, err := os.Getwd()
 	if err != nil {
@@ -100,5 +100,5 @@ func readConfigFile() Config {
 	if conf.ConnectionStr == "" {
 		log.Fatal("Connection string is required in the config file")
 	}
-	return configWithDefaults(conf)
+	return configWithDefaults(&conf)
 }

--- a/core/model.go
+++ b/core/model.go
@@ -206,6 +206,9 @@ func (m Model[T]) CountDocuments(query ...primitive.M) Model[T] {
 		if err != nil {
 			panic(err)
 		}
+		if len(results) == 0 {
+			return 0
+		}
 		return cast.ToInt64(results[0]["count"])
 	}
 	return m

--- a/tests/cmd_test.go
+++ b/tests/cmd_test.go
@@ -1,0 +1,41 @@
+package e_tests
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
+
+	e_cmd "github.com/elcengine/elemental/cmd"
+	e_mocks "github.com/elcengine/elemental/tests/mocks"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestCmd(t *testing.T) {
+	originalDir, _ := os.Getwd()
+	defer os.Chdir(originalDir)
+
+	os.Chdir("..")
+
+	os.Remove(e_cmd.DefaultConfigFile)
+
+	Convey("Initialize config file", t, func() {
+		_, err := os.Stat(e_cmd.DefaultConfigFile)
+		So(errors.Is(err, os.ErrNotExist), ShouldBeTrue)
+
+		e_cmd.RootCmd.SetArgs([]string{"init", e_mocks.DEFAULT_DATASOURCE})
+		e_cmd.Execute()
+
+		_, err = os.Stat(e_cmd.DefaultConfigFile)
+		So(errors.Is(err, os.ErrNotExist), ShouldBeFalse)
+
+		file, err := os.ReadFile(e_cmd.DefaultConfigFile)
+		So(err, ShouldBeNil)
+
+		cfg := e_cmd.Config{}
+		err = json.Unmarshal(file, &cfg)
+		So(err, ShouldBeNil)
+
+		So(cfg.ConnectionStr, ShouldEqual, e_mocks.DEFAULT_DATASOURCE)
+	})
+}

--- a/tests/cmd_test.go
+++ b/tests/cmd_test.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 package e_tests
 
 import (
@@ -21,6 +22,10 @@ func TestCmd(t *testing.T) {
 	os.Chdir("..")
 
 	os.Remove(e_cmd.DefaultConfigFile)
+
+	Convey("Call root command", t, func() {
+		So(e_cmd.Execute, ShouldNotPanic)
+	})
 
 	Convey("Initialize config file", t, func() {
 		_, err := os.Stat(e_cmd.DefaultConfigFile)

--- a/tests/cmd_test.go
+++ b/tests/cmd_test.go
@@ -4,11 +4,14 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 
-	e_cmd "github.com/elcengine/elemental/cmd"
-	e_mocks "github.com/elcengine/elemental/tests/mocks"
+	"github.com/elcengine/elemental/cmd"
+	"github.com/elcengine/elemental/core"
+	"github.com/elcengine/elemental/tests/mocks"
 	. "github.com/smartystreets/goconvey/convey"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 func TestCmd(t *testing.T) {
@@ -37,5 +40,88 @@ func TestCmd(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		So(cfg.ConnectionStr, ShouldEqual, e_mocks.DEFAULT_DATASOURCE)
+	})
+
+	Convey("Migrations and seeds", t, func() {
+		checkIfFileExists := func(filename, dir string) bool {
+			files, err := os.ReadDir(dir)
+			if err != nil {
+				return false
+			}
+			found := false
+			for _, file := range files {
+				if !file.IsDir() && strings.Contains(file.Name(), filename) {
+					found = true
+					break
+				}
+			}
+			return found
+		}
+		Convey("Create migration file", func() {
+			filename := "rename_name_to_full_name"
+			migrationFileDir := "./database/migrations"
+
+			os.RemoveAll(migrationFileDir)
+
+			So(checkIfFileExists(filename, migrationFileDir), ShouldBeFalse)
+
+			e_cmd.RootCmd.SetArgs([]string{"migrate", "create", filename})
+			e_cmd.Execute()
+
+			So(checkIfFileExists(filename, migrationFileDir), ShouldBeTrue)
+
+			Convey("Run migration", func() {
+				e_cmd.RootCmd.SetArgs([]string{"migrate", "up"})
+				e_cmd.Execute()
+
+				elemental.Connect(e_mocks.DEFAULT_DATASOURCE)
+
+				So(elemental.NativeModel.SetCollection("changelog").
+					CountDocuments(primitive.M{"type": "migration"}).ExecInt(), ShouldEqual, 1)
+
+				Convey("Rollback migration", func() {
+					e_cmd.RootCmd.SetArgs([]string{"migrate", "down"})
+					e_cmd.Execute()
+
+					elemental.Connect(e_mocks.DEFAULT_DATASOURCE)
+
+					So(elemental.NativeModel.SetCollection("changelog").
+						CountDocuments(primitive.M{"type": "migration"}).ExecInt(), ShouldEqual, 0)
+				})
+			})
+		})
+		Convey("Create seed file", func() {
+			filename := "create_test_user"
+			seedFileDir := "./database/seeds"
+
+			os.RemoveAll(seedFileDir)
+
+			So(checkIfFileExists(filename, seedFileDir), ShouldBeFalse)
+
+			e_cmd.RootCmd.SetArgs([]string{"seed", "create", filename})
+			e_cmd.Execute()
+
+			So(checkIfFileExists(filename, seedFileDir), ShouldBeTrue)
+
+			Convey("Run seed", func() {
+				e_cmd.RootCmd.SetArgs([]string{"seed", "up"})
+				e_cmd.Execute()
+
+				elemental.Connect(e_mocks.DEFAULT_DATASOURCE)
+
+				So(elemental.NativeModel.SetCollection("changelog").
+					CountDocuments(primitive.M{"type": "seed"}).ExecInt(), ShouldEqual, 1)
+
+				Convey("Rollback seed", func() {
+					e_cmd.RootCmd.SetArgs([]string{"seed", "down"})
+					e_cmd.Execute()
+
+					elemental.Connect(e_mocks.DEFAULT_DATASOURCE)
+
+					So(elemental.NativeModel.SetCollection("changelog").
+						CountDocuments(primitive.M{"type": "seed"}).ExecInt(), ShouldEqual, 0)
+				})
+			})
+		})
 	})
 }


### PR DESCRIPTION
## Summary by Sourcery

Export and refactor config and CLI commands, introduce DefaultConfigFile constant, enhance init command to initialize a config file with a default connection string, and add a test to verify the init command's behavior.

Enhancements:
- Export Config struct and rename rootCmd to RootCmd for public CLI access
- Introduce DefaultConfigFile constant and replace hard-coded filename in the init command
- Refactor init command to use lo.FirstOrEmpty to populate ConnectionStr in the generated config

Tests:
- Add a test for the init command to verify config file creation and validate its contents