### PR TITLE
fix: generated module name in migration executor

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - main
+      - blizzard
 
 jobs:
     lint:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - main
+      - blizzard
   workflow_dispatch:
 
 jobs:

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -3,8 +3,6 @@ package e_cmd
 
 import (
 	"fmt"
-	"github.com/elcengine/elemental/core"
-	"github.com/elcengine/elemental/utils"
 	"log"
 	"os"
 	"os/exec"
@@ -12,6 +10,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/elcengine/elemental/core"
+	"github.com/elcengine/elemental/utils"
 
 	"github.com/samber/lo"
 	"github.com/spf13/cast"
@@ -45,6 +46,8 @@ func run(rollback bool, target string) {
 		return file1Timestamp < file2Timestamp
 	})
 
+	module := string(lo.Must(exec.Command("go", "list", "-m").Output()))
+
 	var template = fmt.Sprintf(`package main 
 
 import (
@@ -54,7 +57,7 @@ import (
 	"time"
 	"go.mongodb.org/mongo-driver/mongo"
 	"github.com/elcengine/elemental/core"
-	"github.com/elcengine/elemental/database/%ss"
+	"%s"
 )
 
  func extractTimestamp(fileName string) int64 {
@@ -99,7 +102,8 @@ func main() {
 	}
 }
 `,
-		target, cfg.ConnectionStr, cfg.ChangelogCollection,
+		strings.TrimSpace(module)+"/"+dir,
+		cfg.ConnectionStr, cfg.ChangelogCollection,
 		strings.Join(lo.Map(files, func(file os.DirEntry, index int) string {
 			return fmt.Sprintf("\"%s\"", strings.TrimSuffix(file.Name(), ".go"))
 		}), ","),


### PR DESCRIPTION
## Summary by Sourcery

Fix module naming logic in migration executor and update CI workflows to include the new branch

Bug Fixes:
- Correct the generated module import path in the migration executor

Enhancements:
- Switch to using dynamic module path construction with trimmed module name
- Add necessary core and utils imports in the migration command

CI:
- Include 'blizzard' branch in pull_request triggers for lint and test workflows