### PR TITLE
feat: added a shorter method for ping

### DIFF
--- a/core/connection.go
+++ b/core/connection.go
@@ -154,10 +154,10 @@ func DropAllDatabases(alias ...string) {
 }
 
 // Pings the primary server of a given connection or the default connection if no alias is provided
-// This will timeout after 2 seconds
+// This will timeout after 5 seconds
 func Ping(alias ...string) error {
 	client := GetConnection(alias...)
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := client.Ping(ctx, readpref.Primary()); err != nil {
 		return err

--- a/core/connection.go
+++ b/core/connection.go
@@ -152,3 +152,15 @@ func DropAllDatabases(alias ...string) {
 		}
 	}
 }
+
+// Pings the primary server of a given connection or the default connection if no alias is provided
+// This will timeout after 2 seconds
+func Ping(alias ...string) error {
+	client := GetConnection(alias...)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx, readpref.Primary()); err != nil {
+		return err
+	}
+	return nil
+}

--- a/tests/connection_test.go
+++ b/tests/connection_test.go
@@ -37,6 +37,9 @@ func TestConnection(t *testing.T) {
 			Convey("Should fire the connection created event", func() {
 				So(connectionCreatedFired, ShouldBeTrue)
 			})
+			Convey("Should ping the primary server", func() {
+				So(elemental.Ping(), ShouldBeNil)
+			})
 		})
 		Convey("Connect with a URI specified within client options", func() {
 			opts := options.Client().ApplyURI(strings.Replace(e_mocks.DEFAULT_DATASOURCE, e_mocks.DEFAULT_DB_NAME, t.Name(), 1))


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new Ping function to simplify checking the primary server connectivity with a 5-second timeout and validate it in tests.

New Features:
- Add Ping function for primary server health check with a 5-second timeout.

Tests:
- Add test to verify Ping returns successfully when the primary server is reachable.