### PR TITLE
fix: renamed packages according to go convention

### DIFF
--- a/core/model_plugins.go
+++ b/core/model_plugins.go
@@ -10,7 +10,7 @@ import "github.com/elcengine/elemental/plugins/filter_query"
 //
 //	UserModel.QS("filter[name]=John&sort[name]=asc&include=field1&select=field1").ExecTT()
 func (m Model[T]) QS(query string) Model[T] {
-	result := filter_query.Parse(query)
+	result := fq.Parse(query)
 	if len(result.Filters) > 0 {
 		m = m.Find(result.Filters)
 	}

--- a/plugins/filter_query/filter_query.go
+++ b/plugins/filter_query/filter_query.go
@@ -1,4 +1,4 @@
-package filter_query
+package fq
 
 import (
 	"strings"

--- a/plugins/filter_query/middleware/gofibre.go
+++ b/plugins/filter_query/middleware/gofibre.go
@@ -1,4 +1,4 @@
-package filter_query_middleware
+package fqm
 
 import (
 	"github.com/elcengine/elemental/plugins/filter_query"
@@ -19,7 +19,7 @@ import (
 //	})
 func NewGoFiber() func(*fiber.Ctx) error {
 	return func(ctx *fiber.Ctx) error {
-		ctx.Locals(CtxKey, filter_query.Parse(string(ctx.Request().URI().QueryString())))
+		ctx.Locals(CtxKey, fq.Parse(string(ctx.Request().URI().QueryString())))
 		return ctx.Next()
 	}
 }

--- a/plugins/filter_query/middleware/middleware.go
+++ b/plugins/filter_query/middleware/middleware.go
@@ -1,3 +1,3 @@
-package filter_query_middleware
+package fqm
 
 const CtxKey = "elementalFilterQuery"

--- a/plugins/filter_query/util.go
+++ b/plugins/filter_query/util.go
@@ -1,5 +1,5 @@
 //nolint:goconst
-package filter_query
+package fq
 
 import (
 	"regexp"

--- a/tests/plugin_filter_query_test.go
+++ b/tests/plugin_filter_query_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	filter_query "github.com/elcengine/elemental/plugins/filter_query"
+	"github.com/elcengine/elemental/plugins/filter_query"
 	e_mocks "github.com/elcengine/elemental/tests/mocks"
 	e_test_setup "github.com/elcengine/elemental/tests/setup"
 
@@ -23,118 +23,118 @@ func TestPluginFilterQuery(t *testing.T) {
 	Convey("Filters", t, func() {
 		Convey("Basic Syntax", func() {
 			Convey("Equality", func() {
-				result := filter_query.Parse("filter[name]=John")
+				result := fq.Parse("filter[name]=John")
 				So(result.Filters, ShouldResemble, bson.M{"name": "John"})
 			})
 		})
 		Convey("Advanced Syntax", func() {
 			Convey("Equality", func() {
-				result := filter_query.Parse("filter[name]=eq(John)")
+				result := fq.Parse("filter[name]=eq(John)")
 				So(result.Filters, ShouldResemble, bson.M{"name": bson.M{"$eq": "John"}})
 			})
 			Convey("Inequality", func() {
-				result := filter_query.Parse("filter[age]=ne(30)")
+				result := fq.Parse("filter[age]=ne(30)")
 				So(result.Filters, ShouldResemble, bson.M{"age": bson.M{"$ne": 30.0}})
 			})
 			Convey("Greater Than", func() {
-				result := filter_query.Parse("filter[age]=gt(30)")
+				result := fq.Parse("filter[age]=gt(30)")
 				So(result.Filters, ShouldResemble, bson.M{"age": bson.M{"$gt": 30.0}})
 			})
 			Convey("Less Than", func() {
-				result := filter_query.Parse("filter[age]=lt(30)")
+				result := fq.Parse("filter[age]=lt(30)")
 				So(result.Filters, ShouldResemble, bson.M{"age": bson.M{"$lt": 30.0}})
 			})
 			Convey("Greater Than or Equal", func() {
-				result := filter_query.Parse("filter[age]=gte(30)")
+				result := fq.Parse("filter[age]=gte(30)")
 				So(result.Filters, ShouldResemble, bson.M{"age": bson.M{"$gte": 30.0}})
 			})
 			Convey("Less Than or Equal", func() {
-				result := filter_query.Parse("filter[age]=lte(30)")
+				result := fq.Parse("filter[age]=lte(30)")
 				So(result.Filters, ShouldResemble, bson.M{"age": bson.M{"$lte": 30.0}})
 			})
 			Convey("In", func() {
-				result := filter_query.Parse("filter[name]=in(John,Jane)")
+				result := fq.Parse("filter[name]=in(John,Jane)")
 				So(result.Filters, ShouldResemble, bson.M{"name": bson.M{"$in": []any{"John", "Jane"}}})
 			})
 			Convey("Not In", func() {
-				result := filter_query.Parse("filter[name]=nin(John,Jane)")
+				result := fq.Parse("filter[name]=nin(John,Jane)")
 				So(result.Filters, ShouldResemble, bson.M{"name": bson.M{"$nin": []any{"John", "Jane"}}})
 			})
 			Convey("Regex", func() {
-				result := filter_query.Parse("filter[name]=reg(^J)")
+				result := fq.Parse("filter[name]=reg(^J)")
 				So(result.Filters, ShouldResemble, bson.M{"name": bson.M{"$regex": primitive.Regex{Pattern: "^J", Options: ""}}})
 			})
 			Convey("Exists", func() {
-				result := filter_query.Parse("filter[name]=exists(true)")
+				result := fq.Parse("filter[name]=exists(true)")
 				So(result.Filters, ShouldResemble, bson.M{"name": bson.M{"$exists": true}})
 			})
 		})
 		Convey("When not present in query string", func() {
-			result := filter_query.Parse("")
+			result := fq.Parse("")
 			So(len(result.Filters), ShouldEqual, 0)
 		})
 	})
 
 	Convey("Sorts", t, func() {
 		Convey("Ascending", func() {
-			result := filter_query.Parse("sort[name]=asc")
+			result := fq.Parse("sort[name]=asc")
 			So(result.Sorts, ShouldResemble, bson.M{"name": 1})
 		})
 		Convey("Ascending with 1", func() {
-			result := filter_query.Parse("sort[name]=1")
+			result := fq.Parse("sort[name]=1")
 			So(result.Sorts, ShouldResemble, bson.M{"name": 1})
 		})
 		Convey("Descending", func() {
-			result := filter_query.Parse("sort[name]=desc")
+			result := fq.Parse("sort[name]=desc")
 			So(result.Sorts, ShouldResemble, bson.M{"name": -1})
 		})
 		Convey("Descending with -1", func() {
-			result := filter_query.Parse("sort[name]=-1")
+			result := fq.Parse("sort[name]=-1")
 			So(result.Sorts, ShouldResemble, bson.M{"name": -1})
 		})
 		Convey("When not present in query string", func() {
-			result := filter_query.Parse("")
+			result := fq.Parse("")
 			So(len(result.Sorts), ShouldEqual, 0)
 		})
 	})
 
 	Convey("Include", t, func() {
 		Convey("When present in query string", func() {
-			result := filter_query.Parse("include=field1,field2")
+			result := fq.Parse("include=field1,field2")
 			So(result.Include, ShouldResemble, []string{"field1", "field2"})
 		})
 		Convey("When not present in query string", func() {
-			result := filter_query.Parse("")
+			result := fq.Parse("")
 			So(len(result.Include), ShouldEqual, 0)
 		})
 	})
 
 	Convey("Select", t, func() {
 		Convey("When present in query string", func() {
-			result := filter_query.Parse("select=field1,field2")
+			result := fq.Parse("select=field1,field2")
 			So(result.Select, ShouldResemble, bson.M{"field1": 1, "field2": 1})
 		})
 		Convey("When present in query string with exclusion", func() {
-			result := filter_query.Parse("select=-field1,field2")
+			result := fq.Parse("select=-field1,field2")
 			So(result.Select, ShouldResemble, bson.M{"field1": 0, "field2": 1})
 		})
 		Convey("When not present in query string", func() {
-			result := filter_query.Parse("")
+			result := fq.Parse("")
 			So(len(result.Select), ShouldEqual, 0)
 		})
 	})
 
 	Convey("Prepaginate", t, func() {
 		Convey("When present in query string as true", func() {
-			result := filter_query.Parse("prepaginate=true")
+			result := fq.Parse("prepaginate=true")
 			So(result.Prepaginate, ShouldBeTrue)
 		})
 		Convey("When present in query string as false", func() {
-			result := filter_query.Parse("prepaginate=false")
+			result := fq.Parse("prepaginate=false")
 			So(result.Prepaginate, ShouldBeFalse)
 		})
 		Convey("When not present in query string", func() {
-			result := filter_query.Parse("")
+			result := fq.Parse("")
 			So(result.Prepaginate, ShouldBeFalse)
 		})
 	})


### PR DESCRIPTION
## Summary by Sourcery

Adopt Go package naming conventions by renaming the filter_query plugin package alias to 'fq' and the middleware package to 'fqm', updating all import paths and code references accordingly.

Enhancements:
- Rename filter_query plugin import alias to 'fq' and update Parse calls in tests, core, and middleware
- Rename filter_query_middleware package to 'fqm' and adjust its package declaration and imports