### PR TITLE
fix: timing issue in handling on connection ready

### DIFF
--- a/core/connection.go
+++ b/core/connection.go
@@ -81,6 +81,7 @@ func Connect(arg any) mongo.Client {
 	}
 	lo.Must0(client.Ping(ctx, readpref.Primary()))
 	clients[opts.Alias] = client
+	triggerEventIfRegistered(opts.Alias, EventDeploymentDiscovered)
 	return *client
 }
 

--- a/core/model.go
+++ b/core/model.go
@@ -13,7 +13,6 @@ import (
 	"github.com/samber/lo"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -64,7 +63,7 @@ func NewModel[T any](name string, schema Schema) Model[T] {
 		middleware: &middleware,
 	}
 	Models[name] = model
-	connectionReady := func() {
+	onConnectionComplete := func() {
 		model.CreateCollection()
 		model.SyncIndexes()
 		if model.Schema.Options.Auditing {
@@ -72,9 +71,9 @@ func NewModel[T any](name string, schema Schema) Model[T] {
 		}
 	}
 	if model.Ping() != nil {
-		OnConnectionEvent(event.ConnectionReady, connectionReady)
+		OnConnectionEvent(EventDeploymentDiscovered, onConnectionComplete)
 	} else {
-		connectionReady()
+		onConnectionComplete()
 	}
 	return model
 }


### PR DESCRIPTION
## Summary by Sourcery

Implement a new DeploymentDiscovered event to reliably invoke connection-ready routines after the initial MongoDB client ping, refactor listener storage to pointers, and tighten listener existence checks.

New Features:
- Add EventDeploymentDiscovered constant to represent post-deployment discovery event

Bug Fixes:
- Fix timing issue by triggering deployment-complete handlers only after successful client Ping

Enhancements:
- Store connection-event handlers as pointers and update trigger logic to dereference safely
- Refactor OnConnectionEvent and PoolMonitor listener checks to use pointer storage and len() checks