### PR TITLE
feat: added option to skip schema validation and improved perf

### DIFF
--- a/core/model_audit.go
+++ b/core/model_audit.go
@@ -3,6 +3,7 @@ package elemental
 import (
 	"context"
 	"reflect"
+	"time"
 
 	e_constants "github.com/elcengine/elemental/constants"
 	e_utils "github.com/elcengine/elemental/utils"
@@ -19,11 +20,11 @@ const (
 )
 
 type Audit struct {
-	Entity    string             `json:"entity" bson:"entity"`         // The name of the model that was audited.
-	Type      AuditType          `json:"type" bson:"type"`             // The type of operation that was performed (insert, update, delete).
-	Document  primitive.M        `json:"document" bson:"document"`     // The document that was affected by the operation.
-	User      string             `json:"user" bson:"user"`             // The user who performed the operation if available within the context.
-	CreatedAt primitive.DateTime `json:"created_at" bson:"created_at"` // The date and time when the operation was performed.
+	Entity    string      `json:"entity" bson:"entity"`         // The name of the model that was audited.
+	Type      AuditType   `json:"type" bson:"type"`             // The type of operation that was performed (insert, update, delete).
+	Document  primitive.M `json:"document" bson:"document"`     // The document that was affected by the operation.
+	User      string      `json:"user" bson:"user"`             // The user who performed the operation if available within the context.
+	CreatedAt time.Time   `json:"created_at" bson:"created_at"` // The date and time when the operation was performed.
 }
 
 var AuditModel = NewModel[Audit]("Audit", NewSchema(map[string]Field{
@@ -42,7 +43,8 @@ var AuditModel = NewModel[Audit]("Audit", NewSchema(map[string]Field{
 		Type: reflect.String,
 	},
 }, SchemaOptions{
-	Collection: "audits",
+	Collection:              "audits",
+	BypassSchemaEnforcement: true,
 }))
 
 // Enables auditing for the current model.
@@ -61,26 +63,29 @@ func (m Model[T]) EnableAuditing(ctx ...context.Context) {
 
 	m.OnInsert(func(doc T) {
 		execWithModelOpts(AuditModel.Create(Audit{
-			Entity:   m.Name,
-			Type:     AuditTypeInsert,
-			Document: *e_utils.ToBSONDoc(doc),
-			User:     e_utils.Cast[string](context.Value(e_constants.CtxUser)),
+			Entity:    m.Name,
+			Type:      AuditTypeInsert,
+			Document:  *e_utils.ToBSONDoc(doc),
+			User:      e_utils.Cast[string](context.Value(e_constants.CtxUser)),
+			CreatedAt: time.Now(),
 		}))
 	}, TriggerOptions{Context: &context, Filter: &primitive.M{"ns.coll": primitive.M{"$eq": m.Collection().Name()}}})
 	m.OnUpdate(func(doc T) {
 		execWithModelOpts(AuditModel.Create(Audit{
-			Entity:   m.Name,
-			Type:     AuditTypeUpdate,
-			Document: *e_utils.ToBSONDoc(doc),
-			User:     e_utils.Cast[string](context.Value(e_constants.CtxUser)),
+			Entity:    m.Name,
+			Type:      AuditTypeUpdate,
+			Document:  *e_utils.ToBSONDoc(doc),
+			User:      e_utils.Cast[string](context.Value(e_constants.CtxUser)),
+			CreatedAt: time.Now(),
 		}))
 	}, TriggerOptions{Context: &context, Filter: &primitive.M{"ns.coll": primitive.M{"$eq": m.Collection().Name()}}})
 	m.OnDelete(func(id primitive.ObjectID) {
 		execWithModelOpts(AuditModel.Create(Audit{
-			Entity:   m.Name,
-			Type:     AuditTypeDelete,
-			Document: map[string]any{"_id": id},
-			User:     e_utils.Cast[string](context.Value(e_constants.CtxUser)),
+			Entity:    m.Name,
+			Type:      AuditTypeDelete,
+			Document:  map[string]any{"_id": id},
+			User:      e_utils.Cast[string](context.Value(e_constants.CtxUser)),
+			CreatedAt: time.Now(),
 		}))
 	}, TriggerOptions{Context: &context, Filter: &primitive.M{"ns.coll": primitive.M{"$eq": m.Collection().Name()}}})
 }

--- a/core/schema_types.go
+++ b/core/schema_types.go
@@ -6,11 +6,12 @@ import (
 )
 
 type SchemaOptions struct {
-	Collection        string                          // Custom collection name, if not set, the lowercase pluralized name of the model will be used.
-	CollectionOptions options.CreateCollectionOptions // Plain mongo driver collection options if you want to set them
-	Database          string                          // Custom database name, if not set, the default database will be used
-	Connection        string                          // Custom connection alias, if not set, the default connection will be used
-	Auditing          bool                            // Whether to enable auditing for this model
+	Collection              string                          // Custom collection name, if not set, the lowercase pluralized name of the model will be used.
+	CollectionOptions       options.CreateCollectionOptions // Plain mongo driver collection options if you want to set them
+	Database                string                          // Custom database name, if not set, the default database will be used
+	Connection              string                          // Custom connection alias, if not set, the default connection will be used
+	Auditing                bool                            // Whether to enable auditing for this model
+	BypassSchemaEnforcement bool                            // Whether to bypass schema enforcement when creating a new document
 }
 
 type Field struct {


### PR DESCRIPTION
## Summary by Sourcery

Introduce an option to bypass schema validation for faster document creation and optimize audit logging, including native timestamp handling.

New Features:
- Add BypassSchemaEnforcement flag to SchemaOptions to allow skipping schema enforcement when creating documents.

Enhancements:
- Modify enforceSchema to respect the bypass flag and short-circuit validation, returning raw BSON for performance.
- Normalize BSON tag extraction in default field setters to ensure clean tag names.
- Update Audit model to use time.Time for CreatedAt and assign timestamps in insert/update/delete hooks.
- Configure AuditModel to bypass schema enforcement for audit entries.