### PR TITLE
feat: added support for passing hex strings to id queries

### DIFF
--- a/core/model.go
+++ b/core/model.go
@@ -178,8 +178,9 @@ func (m Model[T]) FindOne(query ...primitive.M) Model[T] {
 }
 
 // Extends the query with a match stage to find a document by its ID.
-func (m Model[T]) FindByID(id primitive.ObjectID) Model[T] {
-	q := primitive.M{"_id": id}
+// The id can be a string or an ObjectID.
+func (m Model[T]) FindByID(id any) Model[T] {
+	q := primitive.M{"_id": e_utils.EnsureObjectID(id)}
 	if m.softDeleteEnabled {
 		q[m.deletedAtFieldName] = primitive.M{"$exists": false}
 	}

--- a/core/model_query_delete.go
+++ b/core/model_query_delete.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"time"
 
-	e_utils "github.com/elcengine/elemental/utils"
+	"github.com/elcengine/elemental/utils"
 	"github.com/samber/lo"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -38,11 +38,13 @@ func (m Model[T]) FindOneAndDelete(query ...primitive.M) Model[T] {
 // It deletes only the first document that matches the id.
 // This method will return the deleted document.
 // If the model has soft delete enabled, it will update the document with a deleted_at field instead of deleting it.
-func (m Model[T]) FindByIdAndDelete(id primitive.ObjectID) Model[T] {
+// The id can be a string or an ObjectID.
+func (m Model[T]) FindByIdAndDelete(id any) Model[T] {
 	if m.softDeleteEnabled {
-		return m.FindOneAndUpdate(lo.ToPtr(primitive.M{"_id": id}), m.softDeletePayload())
+		return m.FindOneAndUpdate(lo.ToPtr(primitive.M{"_id": e_utils.EnsureObjectID(id)}),
+			m.softDeletePayload())
 	} else {
-		return m.FindOneAndDelete(primitive.M{"_id": id})
+		return m.FindOneAndDelete(primitive.M{"_id": e_utils.EnsureObjectID(id)})
 	}
 }
 
@@ -71,11 +73,12 @@ func (m Model[T]) DeleteOne(query ...primitive.M) Model[T] {
 // It deletes only the first document that matches the id.
 // This method will not return the deleted document.
 // If the model has soft delete enabled, it will update the document with a deleted_at field instead of deleting it.
-func (m Model[T]) DeleteByID(id primitive.ObjectID) Model[T] {
+// The id can be a string or an ObjectID.
+func (m Model[T]) DeleteByID(id any) Model[T] {
 	if m.softDeleteEnabled {
-		return m.UpdateOne(lo.ToPtr(primitive.M{"_id": id}), m.softDeletePayload())
+		return m.UpdateOne(lo.ToPtr(primitive.M{"_id": e_utils.EnsureObjectID(id)}), m.softDeletePayload())
 	} else {
-		return m.DeleteOne(primitive.M{"_id": id})
+		return m.DeleteOne(primitive.M{"_id": e_utils.EnsureObjectID(id)})
 	}
 }
 

--- a/core/model_query_delete.go
+++ b/core/model_query_delete.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/elcengine/elemental/utils"
+	e_utils "github.com/elcengine/elemental/utils"
 	"github.com/samber/lo"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -39,7 +39,7 @@ func (m Model[T]) FindOneAndDelete(query ...primitive.M) Model[T] {
 // This method will return the deleted document.
 // If the model has soft delete enabled, it will update the document with a deleted_at field instead of deleting it.
 // The id can be a string or an ObjectID.
-func (m Model[T]) FindByIdAndDelete(id any) Model[T] {
+func (m Model[T]) FindByIDAndDelete(id any) Model[T] {
 	if m.softDeleteEnabled {
 		return m.FindOneAndUpdate(lo.ToPtr(primitive.M{"_id": e_utils.EnsureObjectID(id)}),
 			m.softDeletePayload())

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -6,7 +6,8 @@ import (
 	"errors"
 	"log"
 
-	elemental "github.com/elcengine/elemental/core"
+	"github.com/elcengine/elemental/core"
+	"github.com/elcengine/elemental/utils"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -46,8 +47,8 @@ func (r Repository[T]) FindOne(query primitive.M) *T {
 	return model
 }
 
-func (r Repository[T]) FindByID(id primitive.ObjectID) *T {
-	return r.FindOne(primitive.M{"_id": id})
+func (r Repository[T]) FindByID(id any) *T {
+	return r.FindOne(primitive.M{"_id": e_utils.EnsureObjectID(id)})
 }
 
 func (r Repository[T]) FindAll() []T {
@@ -60,15 +61,17 @@ func (r Repository[T]) FindAll() []T {
 	return users
 }
 
-func (r Repository[T]) Update(id primitive.ObjectID, payload T) {
-	_, err := elemental.UseDefaultDatabase().Collection(r.collection).UpdateOne(context.Background(), primitive.M{"_id": id}, primitive.M{"$set": payload})
+func (r Repository[T]) Update(id any, payload T) {
+	_, err := elemental.UseDefaultDatabase().Collection(r.collection).
+		UpdateOne(context.Background(), primitive.M{"_id": e_utils.EnsureObjectID(id)}, primitive.M{"$set": payload})
 	if err != nil {
 		panic(err)
 	}
 }
 
-func (r Repository[T]) Delete(id primitive.ObjectID) {
-	_, err := elemental.UseDefaultDatabase().Collection(r.collection).DeleteOne(context.Background(), primitive.M{"_id": id})
+func (r Repository[T]) Delete(id any) {
+	_, err := elemental.UseDefaultDatabase().Collection(r.collection).
+		DeleteOne(context.Background(), primitive.M{"_id": e_utils.EnsureObjectID(id)})
 	if err != nil {
 		panic(err)
 	}

--- a/tests/core_delete_test.go
+++ b/tests/core_delete_test.go
@@ -3,10 +3,10 @@ package e_tests
 import (
 	"testing"
 
-	"github.com/elcengine/elemental/tests/mocks"
-	"github.com/elcengine/elemental/tests/setup"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
+	e_mocks "github.com/elcengine/elemental/tests/mocks"
+	e_test_setup "github.com/elcengine/elemental/tests/setup"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -28,14 +28,14 @@ func TestCoreDelete(t *testing.T) {
 		Convey("Find and delete user by ID", func() {
 			user := UserModel.FindOne().ExecT()
 			So(user.Name, ShouldEqual, e_mocks.Geralt.Name)
-			deletedUser := UserModel.FindByIdAndDelete(user.ID).ExecT()
+			deletedUser := UserModel.FindByIDAndDelete(user.ID).ExecT()
 			So(deletedUser.Name, ShouldEqual, e_mocks.Geralt.Name)
 			So(UserModel.FindByID(user.ID).Exec(), ShouldBeNil)
 
 			Convey("Find and delete user by ID (Hex String)", func() {
 				user := UserModel.FindOne(primitive.M{"name": e_mocks.Imlerith.Name}).ExecT()
 				So(user.Name, ShouldEqual, e_mocks.Imlerith.Name)
-				deletedUser := UserModel.FindByIdAndDelete(user.ID.Hex()).ExecT()
+				deletedUser := UserModel.FindByIDAndDelete(user.ID.Hex()).ExecT()
 				So(deletedUser.Name, ShouldEqual, e_mocks.Imlerith.Name)
 				So(UserModel.FindByID(user.ID).Exec(), ShouldBeNil)
 			})

--- a/tests/core_delete_test.go
+++ b/tests/core_delete_test.go
@@ -1,9 +1,11 @@
 package e_tests
 
 import (
+	"testing"
+
 	"github.com/elcengine/elemental/tests/mocks"
 	"github.com/elcengine/elemental/tests/setup"
-	"testing"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -29,6 +31,14 @@ func TestCoreDelete(t *testing.T) {
 			deletedUser := UserModel.FindByIdAndDelete(user.ID).ExecT()
 			So(deletedUser.Name, ShouldEqual, e_mocks.Geralt.Name)
 			So(UserModel.FindByID(user.ID).Exec(), ShouldBeNil)
+
+			Convey("Find and delete user by ID (Hex String)", func() {
+				user := UserModel.FindOne(primitive.M{"name": e_mocks.Imlerith.Name}).ExecT()
+				So(user.Name, ShouldEqual, e_mocks.Imlerith.Name)
+				deletedUser := UserModel.FindByIdAndDelete(user.ID.Hex()).ExecT()
+				So(deletedUser.Name, ShouldEqual, e_mocks.Imlerith.Name)
+				So(UserModel.FindByID(user.ID).Exec(), ShouldBeNil)
+			})
 		})
 		Convey("Delete a user document", func() {
 			user := UserModel.FindOne().ExecT()

--- a/tests/core_read_test.go
+++ b/tests/core_read_test.go
@@ -89,6 +89,12 @@ func TestCoreRead(t *testing.T) {
 			userById := UserModel.FindByID(user.ID).ExecPtr()
 			So(userById, ShouldNotBeNil)
 			So(userById.Name, ShouldEqual, e_mocks.Ciri.Name)
+
+			Convey("Find user by ID (Hex String)", func() {
+				userById := UserModel.FindByID(user.ID.Hex()).ExecPtr()
+				So(userById, ShouldNotBeNil)
+				So(userById.Name, ShouldEqual, e_mocks.Ciri.Name)
+			})
 		})
 		Convey("Count users", func() {
 			count := UserModel.CountDocuments().ExecInt()

--- a/tests/core_schedule_test.go
+++ b/tests/core_schedule_test.go
@@ -20,8 +20,6 @@ func TestCoreSchedule(t *testing.T) {
 			Name: uuid.NewString(),
 		}).Schedule("*/2 * * * * *").ExecInt()
 
-		defer KingdomModel.Unschedule(id)
-
 		for i := range 3 {
 			SoTimeout(t, func() (ok bool) {
 				if len(KingdomModel.Find().ExecTT()) >= i {
@@ -31,6 +29,8 @@ func TestCoreSchedule(t *testing.T) {
 			})
 			time.Sleep(2 * time.Second)
 		}
+
+		KingdomModel.Unschedule(id)
 
 		time.Sleep(1 * time.Second)
 	})

--- a/tests/core_schedule_test.go
+++ b/tests/core_schedule_test.go
@@ -31,5 +31,7 @@ func TestCoreSchedule(t *testing.T) {
 			})
 			time.Sleep(2 * time.Second)
 		}
+
+		time.Sleep(1 * time.Second)
 	})
 }

--- a/tests/core_update_test.go
+++ b/tests/core_update_test.go
@@ -63,6 +63,14 @@ func TestCoreUpdate(t *testing.T) {
 			}).Exec()
 			updatedUser := UserModel.FindByID(user.ID).ExecT()
 			So(updatedUser.Name, ShouldEqual, "Triss Merigold")
+
+			Convey("Update user by ID (Hex String)", func() {
+				UserModel.UpdateByID(user.ID.Hex(), User{
+					Name: "Triss Merigold the Fearless",
+				}).Exec()
+				updatedUser := UserModel.FindByID(user.ID).ExecT()
+				So(updatedUser.Name, ShouldEqual, "Triss Merigold the Fearless")
+			})
 		})
 		Convey("Update a user document", func() {
 			user := UserModel.FindOne().Where("name", e_mocks.Eredin.Name).ExecT()

--- a/utils/query.go
+++ b/utils/query.go
@@ -11,3 +11,14 @@ func MergedQueryOrDefault(query []primitive.M) primitive.M {
 	}
 	return lo.Assign(query...)
 }
+
+func EnsureObjectID(id any) primitive.ObjectID {
+	if idStr, ok := id.(string); ok {
+		return lo.Must(primitive.ObjectIDFromHex(idStr))
+	} else if idRaw, ok := id.(primitive.ObjectID); ok {
+		return idRaw
+	} else if idPtr, ok := id.(*primitive.ObjectID); ok {
+		return *idPtr
+	}
+	return primitive.NilObjectID
+}

--- a/utils/query.go
+++ b/utils/query.go
@@ -14,7 +14,11 @@ func MergedQueryOrDefault(query []primitive.M) primitive.M {
 
 func EnsureObjectID(id any) primitive.ObjectID {
 	if idStr, ok := id.(string); ok {
-		return lo.Must(primitive.ObjectIDFromHex(idStr))
+		parsed, err := primitive.ObjectIDFromHex(idStr)
+		if err != nil {
+			return primitive.NilObjectID
+		}
+		return parsed
 	} else if idRaw, ok := id.(primitive.ObjectID); ok {
 		return idRaw
 	} else if idPtr, ok := id.(*primitive.ObjectID); ok {


### PR DESCRIPTION
## Summary by Sourcery

Enable acceptance of hex string IDs alongside ObjectID across all model and repository CRUD operations, consolidate filter merging using maps.Copy, and add corresponding hex string ID tests.

New Features:
- Allow passing hex string or ObjectID to id-based query and update methods (FindByID, UpdateByID, ReplaceByID, DeleteByID, FindOneAndUpdate, etc.)

Enhancements:
- Introduce EnsureObjectID utility to normalize various id types to primitive.ObjectID
- Replace manual filter loops with maps.Copy for merging findMatchStage filters
- Refactor repository methods to accept any id type and delegate ID normalization

Tests:
- Add test cases covering hex string ID usage for find, update, and delete operations in core_read, core_update, and core_delete tests