### PR TITLE
feat: parsed page and limit inside filter query

### DIFF
--- a/core/model_schedule.go
+++ b/core/model_schedule.go
@@ -16,6 +16,9 @@ func (m Model[T]) Schedule(spec string) Model[T] {
 // Unschedule a query that was previously scheduled.
 func (m Model[T]) Unschedule(id int) {
 	cron.Remove(robocron.EntryID(id))
+	if len(cron.Entries()) == 0 {
+		cron.Stop()
+	}
 }
 
 // Unschedule all queries that were previously scheduled.

--- a/plugins/filter_query/filter_query.go
+++ b/plugins/filter_query/filter_query.go
@@ -51,10 +51,10 @@ func Parse(queryString string) FilterQueryResult {
 				}
 			}
 		}
-		if strings.Contains(key, "include") {
+		if key == "include" {
 			result.Include = append(result.Include, strings.Split(value, ",")...)
 		}
-		if strings.Contains(key, "select") {
+		if key == "select" {
 			for _, field := range strings.Split(value, ",") {
 				if strings.HasPrefix(field, "-") {
 					result.Select[field[1:]] = 0
@@ -63,20 +63,14 @@ func Parse(queryString string) FilterQueryResult {
 				}
 			}
 		}
-		if strings.Contains(key, "prepaginate") {
+		if key == "prepaginate" {
 			result.Prepaginate = value == "true"
 		}
-		if strings.Contains(key, "page") {
-			result.Page = cast.ToInt(value)
-			if result.Page < 0 {
-				result.Page = 0
-			}
+		if key == "page" {
+			result.Page = max(cast.ToInt(value), 0)
 		}
-		if strings.Contains(key, "limit") {
-			result.Limit = cast.ToInt(value)
-			if result.Limit < 0 {
-				result.Limit = 0
-			}
+		if key == "limit" {
+			result.Limit = max(cast.ToInt(value), 0)
 		}
 	}
 	result.Filters = mapFilters(result.Filters)

--- a/plugins/filter_query/filter_query.go
+++ b/plugins/filter_query/filter_query.go
@@ -1,9 +1,9 @@
 package fq
 
 import (
-	"strings"
-
+	"github.com/spf13/cast"
 	"go.mongodb.org/mongo-driver/bson"
+	"strings"
 )
 
 type FilterQueryResult struct {
@@ -13,6 +13,8 @@ type FilterQueryResult struct {
 	Include          []string // Fields to populate/lookup in the result set
 	Select           bson.M   // Fields to select in the result set
 	Prepaginate      bool     // Whether to paginate the results before any lookups
+	Page             int      // The page number for pagination
+	Limit            int      // The page size for pagination
 }
 
 // Parses the given query string into a Elemental FilterQueryResult.
@@ -63,6 +65,18 @@ func Parse(queryString string) FilterQueryResult {
 		}
 		if strings.Contains(key, "prepaginate") {
 			result.Prepaginate = value == "true"
+		}
+		if strings.Contains(key, "page") {
+			result.Page = cast.ToInt(value)
+			if result.Page < 0 {
+				result.Page = 0
+			}
+		}
+		if strings.Contains(key, "limit") {
+			result.Limit = cast.ToInt(value)
+			if result.Limit < 0 {
+				result.Limit = 0
+			}
 		}
 	}
 	result.Filters = mapFilters(result.Filters)

--- a/tests/plugin_filter_query_test.go
+++ b/tests/plugin_filter_query_test.go
@@ -139,6 +139,44 @@ func TestPluginFilterQuery(t *testing.T) {
 		})
 	})
 
+	Convey("Page", t, func() {
+		Convey("When present in query string", func() {
+			result := fq.Parse("page=2")
+			So(result.Page, ShouldEqual, 2)
+		})
+		Convey("When not present in query string", func() {
+			result := fq.Parse("")
+			So(result.Page, ShouldEqual, 0)
+		})
+		Convey("When present in query string with invalid value", func() {
+			result := fq.Parse("page=invalid")
+			So(result.Page, ShouldEqual, 0)
+		})
+		Convey("When present in query string with negative value", func() {
+			result := fq.Parse("page=-1")
+			So(result.Page, ShouldEqual, 0)
+		})
+	})
+
+	Convey("Limit", t, func() {
+		Convey("When present in query string", func() {
+			result := fq.Parse("limit=10")
+			So(result.Limit, ShouldEqual, 10)
+		})
+		Convey("When not present in query string", func() {
+			result := fq.Parse("")
+			So(result.Limit, ShouldEqual, 0)
+		})
+		Convey("When present in query string with invalid value", func() {
+			result := fq.Parse("limit=invalid")
+			So(result.Limit, ShouldEqual, 0)
+		})
+		Convey("When present in query string with negative value", func() {
+			result := fq.Parse("limit=-10")
+			So(result.Limit, ShouldEqual, 0)
+		})
+	})
+
 	Convey("QS", t, func() {
 		Convey("When a filter is present in query string", func() {
 			results := UserModel.QS(fmt.Sprintf("filter[name]=eq(%s)", e_mocks.Caranthir.Name)).ExecTT()


### PR DESCRIPTION
## Summary by Sourcery

Add pagination support to the filter query plugin by introducing Page and Limit fields in FilterQueryResult and parsing them from the query string with validation.

New Features:
- Add page and limit fields to FilterQueryResult for pagination
- Parse page and limit query parameters with casting and non-negative enforcement

Tests:
- Add tests for page parameter parsing covering valid, missing, invalid, and negative values
- Add tests for limit parameter parsing covering valid, missing, invalid, and negative values