### PR TITLE
fix: paginate result types and added ExecTP helper

### DIFF
--- a/core/model_plugins.go
+++ b/core/model_plugins.go
@@ -34,5 +34,8 @@ func (m Model[T]) QSR(result fq.FilterQueryResult) Model[T] {
 	if len(result.Select) > 0 {
 		m = m.Select(result.Select)
 	}
+	if result.Page > 0 && result.Limit > 0 {
+		m = m.Paginate(result.Page, result.Limit)
+	}
 	return m
 }

--- a/core/model_query.go
+++ b/core/model_query.go
@@ -104,6 +104,14 @@ func (m Model[T]) ExecTT(ctx ...context.Context) []T {
 	return e_utils.Cast[[]T](result)
 }
 
+// ExecTP is a convenience method that executes the query and returns the results as a PaginateResult.
+// It is a type safe method, so you don't need to cast the result. If the query returns nothing, it will return an empty PaginateResult.
+// This method is useful for pagination queries.
+func (m Model[T]) ExecTP(ctx ...context.Context) PaginateResult[T] {
+	result := m.Exec(ctx...)
+	return e_utils.Cast[PaginateResult[T]](result)
+}
+
 // ExecInt is a convenience method that executes the query and returns the first result as an int.
 // It is a type safe method, so you don't need to cast the result. If the query returns nothing
 // it will return 0.

--- a/plugins/filter_query/filter_query.go
+++ b/plugins/filter_query/filter_query.go
@@ -13,8 +13,8 @@ type FilterQueryResult struct {
 	Include          []string // Fields to populate/lookup in the result set
 	Select           bson.M   // Fields to select in the result set
 	Prepaginate      bool     // Whether to paginate the results before any lookups
-	Page             int      // The page number for pagination
-	Limit            int      // The page size for pagination
+	Page             int64    // The page number for pagination
+	Limit            int64    // The page size for pagination
 }
 
 // Parses the given query string into a Elemental FilterQueryResult.
@@ -67,10 +67,10 @@ func Parse(queryString string) FilterQueryResult {
 			result.Prepaginate = value == "true"
 		}
 		if key == "page" {
-			result.Page = max(cast.ToInt(value), 0)
+			result.Page = max(cast.ToInt64(value), 0)
 		}
 		if key == "limit" {
-			result.Limit = max(cast.ToInt(value), 0)
+			result.Limit = max(cast.ToInt64(value), 0)
 		}
 	}
 	result.Filters = mapFilters(result.Filters)

--- a/tests/plugin_filter_query_test.go
+++ b/tests/plugin_filter_query_test.go
@@ -200,5 +200,11 @@ func TestPluginFilterQuery(t *testing.T) {
 			So(results[0].Name, ShouldBeZeroValue)
 			So(results[0].Age, ShouldEqual, e_mocks.Geralt.Age)
 		})
+		Convey("When a page and limit are present in query string", func() {
+			result := UserModel.QS("page=1&limit=2").ExecTP()
+			So(result.Docs, ShouldHaveLength, 2)
+			So(result.Docs[0].Name, ShouldEqual, e_mocks.Ciri.Name)
+			So(result.Docs[1].Name, ShouldEqual, e_mocks.Geralt.Name)
+		})
 	})
 }


### PR DESCRIPTION
## Summary by Sourcery

Introduce a type-safe ExecTP helper for paginated queries, unify pagination parameter types, integrate pagination logic into the filter query plugin, and add corresponding tests

New Features:
- Add ExecTP method to Model for type-safe paginated query results

Enhancements:
- Change FilterQueryResult pagination fields (Page and Limit) from int to int64 and update parsing to use ToInt64
- Enable automatic pagination in Model.QSR when both page and limit are provided

Tests:
- Add test case verifying pagination behavior using ExecTP