### PR TITLE
fix: gracefully handled schedule errors

### DIFF
--- a/core/model.go
+++ b/core/model.go
@@ -37,6 +37,7 @@ type Model[T any] struct {
 	temporaryDatabase   *string
 	temporaryCollection *string
 	schedule            *string
+	onScheduleExecError *func(any)
 	softDeleteEnabled   bool
 	deletedAtFieldName  string
 }

--- a/core/model_query.go
+++ b/core/model_query.go
@@ -63,7 +63,14 @@ func (m Model[T]) Exec(ctx ...context.Context) any {
 	}
 	if m.schedule != nil {
 		id, err := cron.AddFunc(*m.schedule, func() {
-			m.executor(m, e_utils.CtxOrDefault(ctx))
+			lo.TryCatchWithErrorValue(func() error {
+				m.executor(m, e_utils.CtxOrDefault(ctx))
+				return nil
+			}, func(err any) {
+				if m.onScheduleExecError != nil {
+					(*m.onScheduleExecError)(err)
+				}
+			})
 		})
 		if err != nil {
 			panic(err)

--- a/core/model_schedule.go
+++ b/core/model_schedule.go
@@ -8,8 +8,12 @@ var cron = robocron.New(robocron.WithSeconds())
 
 // Marks this query to be executed on a given schedule.
 // For the schedule format, see https://pkg.go.dev/github.com/robfig/cron/v3#hdr-CRON_Expression_Format
-func (m Model[T]) Schedule(spec string) Model[T] {
+// Optionally accepts a function to be called on an execution error/panic.
+func (m Model[T]) Schedule(spec string, onExecutionError ...func(any)) Model[T] {
 	m.schedule = &spec
+	if len(onExecutionError) > 0 {
+		m.onScheduleExecError = &onExecutionError[0]
+	}
 	return m
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Ensure scheduled model queries handle execution errors gracefully without panicking by wrapping the executor in an error catcher and exposing an optional callback, and add tests to verify this behavior and proper unscheduling.

New Features:
- Allow Schedule() to accept an optional onExecutionError callback for handling runtime errors in scheduled tasks.

Enhancements:
- Wrap cron job invocation with TryCatch to catch and forward execution errors instead of panicking.

Tests:
- Add tests to verify error callback is invoked on scheduling failures and to ensure scheduled jobs are unscheduled after execution.