### PR TITLE
test: added benchmark scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
         - name: Checkout repository
           uses: actions/checkout@v4
 
-        - name: Set up Golang 1.23
+        - name: Set up Golang 1.24
           uses: actions/setup-go@v5
           with:
-           go-version: 1.23
+           go-version: 1.24
         
         - name: Release
           uses: go-semantic-release/action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,9 @@ jobs:
         - name: Checkout repository
           uses: actions/checkout@v4
 
+        - name: Disable Go toolchain auto-upgrade
+          run: echo "GOTOOLCHAIN=local" >> $GITHUB_ENV
+
         - name: Set up Golang ${{ matrix.go-version }}
           uses: actions/setup-go@v5
           with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,9 @@ jobs:
           uses: actions/checkout@v4
 
         - name: Disable Go toolchain auto-upgrade
-          run: echo "GOTOOLCHAIN=local" >> $GITHUB_ENV
+          run: |
+            echo "GOTOOLCHAIN=local" >> $GITHUB_ENV
+            sed -i 's/^go 1.24$/go ${{ matrix.go-version }}/' go.mod
 
         - name: Set up Golang ${{ matrix.go-version }}
           uses: actions/setup-go@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,8 @@ jobs:
         strategy:
           matrix:
             go-version:
-              - "1.22"
               - "1.23"
+              - "1.24"
             mongo-version:
               - "6.0"
               - "8.0"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
         strategy:
           matrix:
             go-version:
-              - "1.21"
+              - "1.22"
               - "1.23"
             mongo-version:
               - "6.0"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,7 @@ linters:
     - tagalign
     - tagliatelle
     - testpackage
+    - usetesting
     - varnamelen
     - wrapcheck
     - wsl

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ format:
 test:
 	PARALLEL_CONVEY=false make test-lightspeed
 test-lightspeed:
-	go test $(GO_TEST_ARGS) -v --count=1 ./tests/...
+	go test $(GO_TEST_ARGS) -v --count=1 --run=Test ./tests/...
 test-coverage:
 	@mkdir -p ./coverage
 	make test-lightspeed GO_TEST_ARGS="--cover -coverpkg=./cmd/...,./constants/...,./core/...,./plugins/...,./utils/... --coverprofile=./coverage/coverage.out"

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,14 @@ format:
 test:
 	PARALLEL_CONVEY=false make test-lightspeed
 test-lightspeed:
-	go test $(GO_TEST_ARGS) -v --count=1 --run=Test ./tests/...
+	go test $(GO_TEST_ARGS) -v --count=1 ./tests/...
 test-coverage:
 	@mkdir -p ./coverage
 	make test-lightspeed GO_TEST_ARGS="--cover -coverpkg=./cmd/...,./constants/...,./core/...,./plugins/...,./utils/... --coverprofile=./coverage/coverage.out"
 	go tool cover -html=./coverage/coverage.out -o ./coverage/index.html
 	@echo "\033[0;32mCoverage report generated at ./coverage/index.html.\033[0m"
 benchmark:
-	go test -bench=. -benchtime=10s ./tests/benchmarks/... 
+	go test -bench=. -benchtime=10s -tags=benchmark ./tests/benchmarks/... 
 lint:
 	golangci-lint run ./...
 lint-fix:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ test-coverage:
 	make test-lightspeed GO_TEST_ARGS="--cover -coverpkg=./cmd/...,./constants/...,./core/...,./plugins/...,./utils/... --coverprofile=./coverage/coverage.out"
 	go tool cover -html=./coverage/coverage.out -o ./coverage/index.html
 	@echo "\033[0;32mCoverage report generated at ./coverage/index.html.\033[0m"
+benchmark:
+	go test -bench=. -benchtime=10s ./tests/benchmarks/... 
 lint:
 	golangci-lint run ./...
 lint-fix:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ go install github.com/elcengine/elemental@latest
 ## Development Setup
 
 ### Prerequisites
- - [Go 1.21 or later](https://golang.org/dl) - The Go programming language
+ - [Go 1.22 or later](https://golang.org/dl) - The Go programming language
  - [Node (optional)](https://nodejs.org/en) - If you want to make use of [commitlint](https://commitlint.js.org)
 
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ go install github.com/elcengine/elemental@latest
 ## Development Setup
 
 ### Prerequisites
- - [Go 1.22 or later](https://golang.org/dl) - The Go programming language
+ - [Go 1.23 or later](https://golang.org/dl) - The Go programming language
  - [Node (optional)](https://nodejs.org/en) - If you want to make use of [commitlint](https://commitlint.js.org)
 
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ go install github.com/elcengine/elemental@latest
 - Run `make test` to run all tests suites.
 - Run `make test-lightspeed` to run the same above tests cost faster at the cost of readability.
 - Run `make test-coverage` to run all test suites and generate a coverage report. Executes with `make test-lightspeed` under the hood.
+- Run `make benchmark` to run all benchmarks.
 - Run `make lint` to run the linter.
+- Run `make format` to format all files.
 
 ## Contributing
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/elcengine/elemental
 go 1.24
 
 require (
-	github.com/akalanka47000/go-modkit/parallel_convey v1.1.1
+	github.com/akalanka47000/go-modkit/parallel_convey v1.1.2
 	github.com/creasty/defaults v1.7.0
 	github.com/gertd/go-pluralize v0.2.1
 	github.com/go-playground/validator/v10 v10.22.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/elcengine/elemental
 
-go 1.23
-
-toolchain go1.23.5
+go 1.24
 
 require (
 	github.com/akalanka47000/go-modkit/parallel_convey v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/akalanka47000/go-modkit/parallel_convey v1.1.1 h1:amcGW277I6sM+aPq/lkhwneszZYzFM0uD4XYdETOMsA=
-github.com/akalanka47000/go-modkit/parallel_convey v1.1.1/go.mod h1:P/5Mq1tKcFDMUjtSXSJfmodMNe9hX0XJdOUslmsKcT0=
+github.com/akalanka47000/go-modkit/parallel_convey v1.1.2 h1:C3xqGyQ6IrpWUOqn5EA8dYdzeOgs7UoLfDTeFBrHhYM=
+github.com/akalanka47000/go-modkit/parallel_convey v1.1.2/go.mod h1:itPhp3g2WlD6Uu3a0a/uuMIp3UMfJsyS3XRmNbuEnew=
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/tests/benchmarks/control_test.go
+++ b/tests/benchmarks/control_test.go
@@ -1,0 +1,16 @@
+package benchmarks
+
+import (
+	"os"
+	"testing"
+
+	ts "github.com/elcengine/elemental/tests/fixtures/setup"
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+
+	ts.Teardown()
+
+	os.Exit(code)
+}

--- a/tests/benchmarks/control_test.go
+++ b/tests/benchmarks/control_test.go
@@ -1,3 +1,5 @@
+//go:build benchmark
+
 package benchmarks
 
 import (

--- a/tests/benchmarks/core_create_benchmark_test.go
+++ b/tests/benchmarks/core_create_benchmark_test.go
@@ -1,0 +1,33 @@
+package benchmarks
+
+import (
+	"testing"
+
+	. "github.com/elcengine/elemental/tests/fixtures"
+	ts "github.com/elcengine/elemental/tests/fixtures/setup"
+	"github.com/google/uuid"
+)
+
+func BenchmarkCoreCreate(b *testing.B) {
+	ts.Connection(b.Name())
+
+	UserModel := UserModel.SetDatabase(b.Name())
+
+	for b.Loop() {
+		UserModel.Create(User{
+			Name: uuid.NewString(),
+		}).ExecT()
+	}
+}
+
+func BenchmarkCoreCreateDriver(b *testing.B) {
+	ts.Connection(b.Name())
+
+	coll := UserModel.SetDatabase(b.Name()).Collection()
+
+	for b.Loop() {
+		coll.InsertOne(b.Context(), User{
+			Name: uuid.NewString(),
+		})
+	}
+}

--- a/tests/benchmarks/core_create_benchmark_test.go
+++ b/tests/benchmarks/core_create_benchmark_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func BenchmarkCoreCreate(b *testing.B) {
+	b.ReportAllocs()
+
 	ts.Connection(b.Name())
 
 	UserModel := UserModel.SetDatabase(b.Name())
@@ -23,6 +25,8 @@ func BenchmarkCoreCreate(b *testing.B) {
 }
 
 func BenchmarkCoreCreateDriver(b *testing.B) {
+	b.ReportAllocs()
+
 	ts.Connection(b.Name())
 
 	coll := UserModel.SetDatabase(b.Name()).Collection()

--- a/tests/benchmarks/core_create_benchmark_test.go
+++ b/tests/benchmarks/core_create_benchmark_test.go
@@ -1,3 +1,5 @@
+//go:build benchmark
+
 package benchmarks
 
 import (


### PR DESCRIPTION
## Summary by Sourcery

Introduce benchmarking support by adding benchmark scripts, bump Go version to 1.24, and update build targets and documentation

New Features:
- Add benchmark targets in Makefile to run performance tests

Enhancements:
- Upgrade Go module to Go 1.24

Build:
- Add `benchmark` and `format` targets to Makefile

Documentation:
- Update README to document benchmark and format commands

Tests:
- Add core create benchmarks and teardown in tests/benchmarks