### PR TITLE
fix: renamed string slice helper to match other functions

### DIFF
--- a/core/model_query.go
+++ b/core/model_query.go
@@ -123,11 +123,11 @@ func (m Model[T]) ExecInt(ctx ...context.Context) int {
 	return cast.ToInt(result)
 }
 
-// ExecStringSlice is a convenience method that executes the query and returns the first result as a slice of strings.
+// ExecSS is a convenience method that executes the query and returns the first result as a slice of strings.
 // It is a type safe method, so you don't need to cast the result. If the query returns nothing
 // it will return an empty slice.
 // This method is useful for queries that return an array of strings, such as distinct queries.
-func (m Model[T]) ExecStringSlice(ctx ...context.Context) []string {
+func (m Model[T]) ExecSS(ctx ...context.Context) []string {
 	result := m.Exec(ctx...)
 	return cast.ToStringSlice(result)
 }

--- a/tests/core_read_test.go
+++ b/tests/core_read_test.go
@@ -138,7 +138,7 @@ func TestCoreRead(t *testing.T) {
 			}, ShouldPanicWith, elemental.ErrMustPairSortArguments)
 		})
 		Convey("Find all distinct witcher schools", func() {
-			schools := UserModel.Distinct("school").ExecStringSlice()
+			schools := UserModel.Distinct("school").ExecSS()
 			So(schools, ShouldHaveLength, 2)
 			So(schools, ShouldContain, mocks.WolfSchool)
 			So(schools, ShouldContain, "")


### PR DESCRIPTION
## Summary by Sourcery

Rename string slice helper method to align naming with other query helpers and update tests accordingly

Enhancements:
- Rename ExecStringSlice method to ExecSS for naming consistency
- Update method documentation to reference ExecSS

Tests:
- Adjust tests to use ExecSS instead of ExecStringSlice