### PR TITLE
feat: added filter query options

### DIFF
--- a/core/model_plugins.go
+++ b/core/model_plugins.go
@@ -18,7 +18,7 @@ func (m Model[T]) QS(query string) Model[T] {
 // Usage:
 //
 //	UserModel.QSR(fq.Parse("filter[name]=John&sort[name]=asc&include=field1&select=field1")).ExecTT()
-func (m Model[T]) QSR(result fq.FilterQueryResult) Model[T] {
+func (m Model[T]) QSR(result fq.Result) Model[T] {
 	if len(result.Filters) > 0 {
 		m = m.Find(result.Filters)
 	}

--- a/plugins/filterquery/filterquery.go
+++ b/plugins/filterquery/filterquery.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-type FilterQueryResult struct {
+type Result struct {
 	Filters          bson.M   // Primary filters which are usually evaluated as the first stage of an aggregation query
 	SecondaryFilters bson.M   // Secondary filters which are usually evaluated after any lookups
 	Sorts            bson.M   // Fields to sort by, with 1 or 'asc' for ascending and -1 or 'desc' for descending
@@ -17,14 +17,19 @@ type FilterQueryResult struct {
 	Limit            int64    // The page size for pagination
 }
 
+// Type alias for the Result struct
+//
+// Deprecated: Use Result instead.
+type FilterQueryResult = Result
+
 // Parses the given query string into a Elemental FilterQueryResult.
-func Parse(queryString string) FilterQueryResult {
-	result := FilterQueryResult{}
+func Parse(qs string) Result {
+	result := Result{}
 	result.Filters = bson.M{}
 	result.SecondaryFilters = bson.M{}
 	result.Sorts = bson.M{}
 	result.Select = bson.M{}
-	queries := strings.Split(queryString, "&")
+	queries := strings.Split(qs, "&")
 	for _, query := range queries {
 		if query == "" {
 			continue

--- a/plugins/filterquery/middleware/gofibre.go
+++ b/plugins/filterquery/middleware/gofibre.go
@@ -3,6 +3,7 @@ package fqm
 import (
 	"github.com/elcengine/elemental/plugins/filterquery"
 	"github.com/gofiber/fiber/v2"
+	"github.com/samber/lo"
 )
 
 // NewGoFiber is a middleware for Fiber that parses the query string and stores the result in the context.
@@ -13,13 +14,19 @@ import (
 //	app := fiber.New()
 //	app.Use(fqm.NewGoFiber())
 //	app.Get("/users", func(ctx *fiber.Ctx) error {
-//		q := ctx.Locals(fqm.CtxKey).(fq.FilterQueryResult)
+//		q := ctx.Locals(fqm.CtxKey).(fq.Result)
 //		users := UserModel.Find(q.Filters).Sort(q.Sorts).Select(q.Select).Populate(q.Include...).ExecTT()
 //		return ctx.JSON(users)
 //	})
-func NewGoFiber() func(*fiber.Ctx) error {
+func NewGoFiber(opts ...Options) func(*fiber.Ctx) error {
 	return func(ctx *fiber.Ctx) error {
-		ctx.Locals(CtxKey, fq.Parse(string(ctx.Request().URI().QueryString())))
+		result := fq.Parse(string(ctx.Request().URI().QueryString()))
+		if len(opts) > 0 {
+			if opts[0].DefaultLimit > 0 {
+				result.Limit = lo.CoalesceOrEmpty(result.Limit, opts[0].DefaultLimit)
+			}
+		}
+		ctx.Locals(CtxKey, result)
 		return ctx.Next()
 	}
 }

--- a/plugins/filterquery/middleware/middleware.go
+++ b/plugins/filterquery/middleware/middleware.go
@@ -1,3 +1,7 @@
 package fqm
 
 const CtxKey = "elementalFilterQuery"
+
+type Options struct {
+	DefaultLimit int64 // Sets a default page size for the parsed query.
+}


### PR DESCRIPTION
## Summary by Sourcery

Add configurable default pagination limit to the filter query middleware and streamline the core filter query API by renaming the result type.

New Features:
- Support a default pagination limit in GoFiber middleware via the new Options.DefaultLimit.
- Allow passing Options to NewGoFiber to apply a default page size when none is specified.

Enhancements:
- Rename the core FilterQueryResult struct to Result and provide a deprecated FilterQueryResult alias for compatibility.
- Simplify the Parse function signature and update it to return the new Result type.
- Update the QSR model method to accept Result instead of FilterQueryResult.