### PR TITLE
ci: added coverage reporting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
             SECONDARY_DATASOURCE: mongodb://127.0.0.1:27018/elemental?replicaSet=rs1
         
         - name: Upload coverage report
-          if: github.event_name == 'pull_request' && github.base_ref == 'main'
+          if: github.event_name == 'pull_request' && github.base_ref == 'main' && matrix.go-version == '1.24' && matrix.mongo-version == '8.0'
           uses: codecov/codecov-action@v5
           with:
             token: ${{ secrets.CODECOV_TOKEN }}  

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,8 +53,14 @@ jobs:
           run: go mod tidy
         
         - name: Run tests
-          run: make test
+          run: make test-coverage
           env:
             DEFAULT_DATASOURCE: mongodb://127.0.0.1:27017/elemental?replicaSet=rs0
             SECONDARY_DATASOURCE: mongodb://127.0.0.1:27018/elemental?replicaSet=rs1
-            
+        
+        - name: Upload coverage report
+          if: github.event_name == 'pull_request' && github.base_ref == 'main'
+          uses: codecov/codecov-action@v5
+          with:
+            token: ${{ secrets.CODECOV_TOKEN }}  
+            files: ./coverage/coverage.out

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test-lightspeed:
 	go test $(GO_TEST_ARGS) -v --count=1 ./tests/...
 test-coverage:
 	@mkdir -p ./coverage
-	make test-lightspeed GO_TEST_ARGS="--cover -coverpkg=./cmd/...,./constants/...,./core/...,./plugins/...,./utils/... --coverprofile=./coverage/coverage.out"
+	make test GO_TEST_ARGS="--cover -coverpkg=./cmd/...,./core/...,./plugins/...,./utils/... --coverprofile=./coverage/coverage.out"
 	go tool cover -html=./coverage/coverage.out -o ./coverage/index.html
 	@echo "\033[0;32mCoverage report generated at ./coverage/index.html.\033[0m"
 benchmark:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
   <a aria-label="CI Tests" href="https://github.com/elcengine/elemental/actions/workflows/tests.yml">
     <img alt="" src="https://github.com/elcengine/elemental/actions/workflows/tests.yml/badge.svg">
   </a>
+  <a aria-label="Code Coverage" href="https://codecov.io/gh/elcengine/elemental" >
+    <img src="https://codecov.io/gh/elcengine/elemental/graph/badge.svg?token=A8JF4V5MEY"/>
+  </a>
 </p>
 
 <hr/>
@@ -47,8 +50,8 @@ go install github.com/elcengine/elemental@latest
 
 - Run `make install` to download all dependencies and install the required tools. This is required only once. Afterwards you could use the traditional `go mod tidy` for dependency management.
 - Run `make test` to run all tests suites.
-- Run `make test-lightspeed` to run the same above tests cost faster at the cost of readability.
-- Run `make test-coverage` to run all test suites and generate a coverage report. Executes with `make test-lightspeed` under the hood.
+- Run `make test-lightspeed` to run the same above tests slightly faster at the cost of readability.
+- Run `make test-coverage` to run all test suites and generate a coverage report.
 - Run `make benchmark` to run all benchmarks.
 - Run `make lint` to run the linter.
 - Run `make format` to format all files.


### PR DESCRIPTION
## Summary by Sourcery

Introduce test coverage reporting by updating the CI workflow, Makefile, and documentation to generate, upload, and display coverage metrics.

Enhancements:
- Modify the `test-coverage` Makefile target to invoke `make test` with refined coverage flags

CI:
- Use `make test-coverage` instead of `make test` in the GitHub Actions tests workflow
- Add a conditional Codecov upload step for pull requests targeting the main branch

Documentation:
- Add a Codecov badge to the README
- Update test-related instructions to include the `make test-coverage` command