### PR TITLE
fix: bug in find one and soft delete

### DIFF
--- a/core/model_query_delete.go
+++ b/core/model_query_delete.go
@@ -121,8 +121,8 @@ func (m Model[T]) DeleteMany(query ...primitive.M) Model[T] {
 }
 
 // Enables soft delete for the model.
-func (m *Model[T]) EnableSoftDelete() {
-	m.deletedAtFieldName = "deleted_at"
+func (m *Model[T]) EnableSoftDelete(deletedAtFieldName ...string) {
+	m.deletedAtFieldName = lo.CoalesceOrEmpty(lo.FirstOrEmpty(deletedAtFieldName), "deleted_at")
 	m.softDeleteEnabled = true
 }
 

--- a/core/model_query_delete.go
+++ b/core/model_query_delete.go
@@ -19,7 +19,7 @@ import (
 func (m Model[T]) FindOneAndDelete(query ...primitive.M) Model[T] {
 	q := utils.MergedQueryOrDefault(query)
 	if m.softDeleteEnabled {
-		m = m.UpdateOne(&q, m.softDeletePayload())
+		m = m.FindOneAndUpdate(&q, m.softDeletePayload())
 	} else {
 		m.executor = func(m Model[T], ctx context.Context) any {
 			var doc T


### PR DESCRIPTION
## Summary by Sourcery

Fix soft delete behavior in FindOneAndDelete and introduce dedicated soft delete tests

Bug Fixes:
- Correct FindOneAndDelete to use FindOneAndUpdate when soft delete is enabled

Enhancements:
- Remove obsolete soft delete test from core_delete_test.go

Tests:
- Add TestCoreSoftDelete suite to verify deleted_at is set across FindOneAndDelete, FindByIDAndDelete, Delete, DeleteByID, and DeleteMany under soft delete