### PR TITLE
Fixes, performance improvements and more tests

### DIFF
--- a/core/model_triggers.go
+++ b/core/model_triggers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/elcengine/elemental/utils"
+	"github.com/samber/lo"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -39,12 +40,9 @@ func (m Model[T]) on(event triggerType, f func(change primitive.M), opts ...Trig
 		}
 	}
 	filters["operationType"] = event
-	cs, err := m.Collection().Watch(ctx, mongo.Pipeline{
+	cs := lo.Must(m.Collection().Watch(ctx, mongo.Pipeline{
 		bson.D{{Key: "$match", Value: filters}},
-	}, options.ChangeStream().SetFullDocument(options.UpdateLookup))
-	if err != nil {
-		panic(err)
-	}
+	}, options.ChangeStream().SetFullDocument(options.UpdateLookup)))
 	go func() {
 		for cs.Next(ctx) {
 			var changeDoc bson.M

--- a/tests/connection_test.go
+++ b/tests/connection_test.go
@@ -13,6 +13,9 @@ import (
 )
 
 func TestConnection(t *testing.T) {
+	Convey("Ping should fail before connection", t, func() {
+		So(elemental.Ping(), ShouldNotBeNil)
+	})
 	Convey("Connect to a local database", t, func() {
 		Convey("Simplest form of connect with just a URI", func() {
 			connectionCreatedFired := false

--- a/tests/connection_test.go
+++ b/tests/connection_test.go
@@ -13,9 +13,6 @@ import (
 )
 
 func TestConnection(t *testing.T) {
-	Convey("Ping should fail before connection", t, func() {
-		So(elemental.Ping(), ShouldNotBeNil)
-	})
 	Convey("Connect to a local database", t, func() {
 		Convey("Simplest form of connect with just a URI", func() {
 			connectionCreatedFired := false

--- a/tests/core_create_test.go
+++ b/tests/core_create_test.go
@@ -33,7 +33,7 @@ func TestCoreCreate(t *testing.T) {
 			So(user.UpdatedAt.Unix(), ShouldBeBetweenOrEqual, time.Now().Add(-10*time.Second).Unix(), time.Now().Unix())
 		})
 		Convey("Create many users", func() {
-			users := UserModel.InsertMany(mocks.Users[1:]).ExecTT()
+			users := UserModel.CreateMany(mocks.Users[1:]).ExecTT()
 			So(len(users), ShouldEqual, len(mocks.Users[1:]))
 			So(users[0].ID, ShouldNotBeNil)
 			So(users[1].ID, ShouldNotBeNil)

--- a/tests/core_model_test.go
+++ b/tests/core_model_test.go
@@ -1,0 +1,34 @@
+package tests
+
+import (
+	"reflect"
+	"testing"
+
+	elemental "github.com/elcengine/elemental/core"
+	ts "github.com/elcengine/elemental/tests/fixtures/setup"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestCoreModel(t *testing.T) {
+	t.Parallel()
+
+	ts.Connection(t.Name())
+
+	UserModel := UserModel.SetDatabase(t.Name())
+
+	Convey("Should clone model", t, func() {
+		ClonedModel := UserModel.Clone()
+		So(ClonedModel.Name, ShouldEqual, UserModel.Name)
+		So(ClonedModel.Cloned, ShouldBeTrue)
+	})
+
+	Convey("Should use cached model", t, func() {
+		CachedUserModel := elemental.NewModel[User]("User", elemental.NewSchema(map[string]elemental.Field{
+			"Name": {
+				Type: reflect.String,
+			},
+		}))
+		So(CachedUserModel.Schema.Definitions, ShouldHaveLength, len(UserModel.Schema.Definitions))
+	})
+}

--- a/tests/core_read_populate_test.go
+++ b/tests/core_read_populate_test.go
@@ -5,6 +5,7 @@ import (
 
 	ts "github.com/elcengine/elemental/tests/fixtures/setup"
 	. "github.com/smartystreets/goconvey/convey"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 func TestCoreReadPopulate(t *testing.T) {
@@ -63,18 +64,31 @@ func TestCoreReadPopulate(t *testing.T) {
 			bestiary := BestiaryModel.Find().Populate("monster").Populate("kingdom").ExecTT()
 			So(bestiary, ShouldHaveLength, 3)
 			So(bestiary[0].Monster.Name, ShouldEqual, "Katakan")
+			So(bestiary[0].Monster.Category, ShouldEqual, "Vampire")
 			So(bestiary[0].Kingdom.Name, ShouldEqual, "Nilfgaard")
 		})
 		Convey("Populate with a single call", func() {
 			bestiary := BestiaryModel.Find().Populate("monster", "kingdom").ExecTT()
 			So(bestiary, ShouldHaveLength, 3)
 			So(bestiary[0].Monster.Name, ShouldEqual, "Katakan")
+			So(bestiary[0].Monster.Category, ShouldEqual, "Vampire")
 			So(bestiary[0].Kingdom.Name, ShouldEqual, "Nilfgaard")
 		})
 		Convey("Populate with a single call (Comma separated string)", func() {
 			bestiary := BestiaryModel.Find().Populate("monster kingdom").ExecTT()
 			So(bestiary, ShouldHaveLength, 3)
 			So(bestiary[0].Monster.Name, ShouldEqual, "Katakan")
+			So(bestiary[0].Monster.Category, ShouldEqual, "Vampire")
+			So(bestiary[0].Kingdom.Name, ShouldEqual, "Nilfgaard")
+		})
+		Convey("Populate with select", func() {
+			bestiary := BestiaryModel.Find().Populate(primitive.M{
+				"path":   "monster",
+				"select": primitive.M{"name": 1},
+			}, "kingdom").ExecTT()
+			So(bestiary, ShouldHaveLength, 3)
+			So(bestiary[0].Monster.Name, ShouldEqual, "Katakan")
+			So(bestiary[0].Monster.Category, ShouldEqual, "")
 			So(bestiary[0].Kingdom.Name, ShouldEqual, "Nilfgaard")
 		})
 	})

--- a/tests/core_soft_delete_test.go
+++ b/tests/core_soft_delete_test.go
@@ -86,6 +86,8 @@ func TestCoreSoftDelete(t *testing.T) {
 			for _, rawUser := range rawUsers {
 				So(rawUser["deleted_at"], ShouldNotBeNil)
 			}
+
+			So(UserModel.CountDocuments().Exec(), ShouldEqual, 0)
 		})
 	})
 }

--- a/tests/core_triggers_test.go
+++ b/tests/core_triggers_test.go
@@ -99,6 +99,10 @@ func TestCoreTriggers(t *testing.T) {
 				return collectionDropped
 			})
 		})
+		Convey("Uninvokable triggers", func() {
+			So(CastleModel.OnCollectionRename(func() {}), ShouldNotBeNil)
+			So(CastleModel.OnStreamInvalidate(func() {}), ShouldNotBeNil)
+		})
 		Convey("Invalidate triggers", func() {
 			CastleModel.InvalidateTriggers()
 			CastleModel.Create(Castle{Name: "Mont Crane"}).Exec()

--- a/utils/math.go
+++ b/utils/math.go
@@ -1,132 +1,63 @@
-//nolint:exhaustive
 package utils
 
 import (
 	"fmt"
-	"reflect"
+	"github.com/spf13/cast"
 )
 
-func parseReflectValue(ar, br reflect.Value) (reflect.Value, reflect.Value) {
-	if ar.Kind() == reflect.Int && br.Kind() == reflect.Float64 {
-		ar = reflect.ValueOf(float64(ar.Int()))
-	}
-	if br.Kind() == reflect.Int && ar.Kind() == reflect.Float64 {
-		br = reflect.ValueOf(float64(br.Int()))
-	}
-	if ar.Kind() == reflect.Int32 && br.Kind() == reflect.Float64 {
-		ar = reflect.ValueOf(float64(ar.Int()))
-	}
-	if br.Kind() == reflect.Int32 && ar.Kind() == reflect.Float64 {
-		br = reflect.ValueOf(float64(br.Int()))
-	}
-	if ar.Kind() == reflect.Int64 && br.Kind() == reflect.Float64 {
-		ar = reflect.ValueOf(float64(ar.Int()))
-	}
-	if br.Kind() == reflect.Int64 && ar.Kind() == reflect.Float64 {
-		br = reflect.ValueOf(float64(br.Int()))
-	}
-	if ar.Kind() == reflect.Int32 && br.Kind() == reflect.Int {
-		ar = reflect.ValueOf(int(ar.Int()))
-	}
-	if br.Kind() == reflect.Int32 && ar.Kind() == reflect.Int {
-		br = reflect.ValueOf(int(br.Int()))
-	}
-	if ar.Kind() == reflect.Int64 && br.Kind() == reflect.Int {
-		ar = reflect.ValueOf(int(ar.Int()))
-	}
-	if br.Kind() == reflect.Int64 && ar.Kind() == reflect.Int {
-		br = reflect.ValueOf(int(br.Int()))
-	}
-	if ar.Kind() == reflect.String && br.Kind() == reflect.Int {
-		br = reflect.ValueOf(fmt.Sprintf("%d", br.Int()))
-	}
-	if ar.Kind() == reflect.Int && br.Kind() == reflect.String {
-		ar = reflect.ValueOf(fmt.Sprintf("%d", ar.Int()))
-	}
-	if ar.Kind() != br.Kind() {
-		panic(fmt.Errorf("type mismatch: cannot compare %s with %s", ar.Kind(), br.Kind()))
-	}
-	return ar, br
-}
-
 func LT(a, b any) bool {
-	ar := reflect.ValueOf(a)
-	br := reflect.ValueOf(b)
-	ar, br = parseReflectValue(ar, br)
-	switch ar.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return ar.Int() < br.Int()
-	case reflect.Float32, reflect.Float64:
-		return ar.Float() < br.Float()
-	case reflect.String:
-		return ar.String() < br.String()
+	switch a.(type) {
+	case int, int8, int16, int32, int64, float32, float64:
+		return cast.ToFloat64(a) < cast.ToFloat64(b)
+	case string:
+		return cast.ToString(a) < cast.ToString(b)
 	default:
-		panic(fmt.Errorf("unsupported type: %s", ar.Kind()))
+		panic(fmt.Errorf("unsupported type: %T", a))
 	}
 }
 
 func LTE(a, b any) bool {
-	ar := reflect.ValueOf(a)
-	br := reflect.ValueOf(b)
-	ar, br = parseReflectValue(ar, br)
-	switch ar.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return ar.Int() <= br.Int()
-	case reflect.Float32, reflect.Float64:
-		return ar.Float() <= br.Float()
-	case reflect.String:
-		return ar.String() <= br.String()
+	switch a.(type) {
+	case int, int8, int16, int32, int64, float32, float64:
+		return cast.ToFloat64(a) <= cast.ToFloat64(b)
+	case string:
+		return cast.ToString(a) <= cast.ToString(b)
 	default:
-		panic(fmt.Errorf("unsupported type: %s", ar.Kind()))
+		panic(fmt.Errorf("unsupported type: %T", a))
 	}
 }
 
 func GT(a, b any) bool {
-	ar := reflect.ValueOf(a)
-	br := reflect.ValueOf(b)
-	ar, br = parseReflectValue(ar, br)
-	switch ar.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return ar.Int() > br.Int()
-	case reflect.Float32, reflect.Float64:
-		return ar.Float() > br.Float()
-	case reflect.String:
-		return ar.String() > br.String()
+	switch a.(type) {
+	case int, int8, int16, int32, int64, float32, float64:
+		return cast.ToFloat64(a) > cast.ToFloat64(b)
+	case string:
+		return cast.ToString(a) > cast.ToString(b)
 	default:
-		panic(fmt.Errorf("unsupported type: %s", ar.Kind()))
+		panic(fmt.Errorf("unsupported type: %T", a))
 	}
 }
 
 func GTE(a, b any) bool {
-	ar := reflect.ValueOf(a)
-	br := reflect.ValueOf(b)
-	ar, br = parseReflectValue(ar, br)
-	switch ar.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return ar.Int() >= br.Int()
-	case reflect.Float32, reflect.Float64:
-		return ar.Float() >= br.Float()
-	case reflect.String:
-		return ar.String() >= br.String()
+	switch a.(type) {
+	case int, int8, int16, int32, int64, float32, float64:
+		return cast.ToFloat64(a) >= cast.ToFloat64(b)
+	case string:
+		return cast.ToString(a) >= cast.ToString(b)
 	default:
-		panic(fmt.Errorf("unsupported type: %s", ar.Kind()))
+		panic(fmt.Errorf("unsupported type: %T", a))
 	}
 }
 
 func EQ(a, b any) bool {
-	ar := reflect.ValueOf(a)
-	br := reflect.ValueOf(b)
-	ar, br = parseReflectValue(ar, br)
-	switch ar.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return ar.Int() == br.Int()
-	case reflect.Float32, reflect.Float64:
-		return ar.Float() == br.Float()
-	case reflect.String:
-		return ar.String() == br.String()
-	case reflect.Bool:
-		return ar.Bool() == br.Bool()
+	switch a.(type) {
+	case int, int8, int16, int32, int64, float32, float64:
+		return cast.ToFloat64(a) == cast.ToFloat64(b)
+	case string:
+		return cast.ToString(a) == cast.ToString(b)
+	case bool:
+		return cast.ToBool(a) == cast.ToBool(b)
 	default:
-		panic(fmt.Errorf("unsupported type: %s", ar.Kind()))
+		panic(fmt.Errorf("unsupported type: %T", a))
 	}
 }


### PR DESCRIPTION
## Summary by Sourcery

Refactor comparison utilities to use cast, simplify and strengthen Populate logic with select support and tag matching fixes, extend tests, and streamline change stream watchers

New Features:
- Support projection in Populate via a select option in the populate configuration
- Expose uninvokable trigger methods (OnCollectionRename, OnStreamInvalidate) to return non-nil values for detection

Bug Fixes:
- Correct bson tag matching in Populate by cleaning tags before comparison
- Prevent duplicate pipeline entries by returning after processing comma-separated populate strings

Enhancements:
- Refactor utils comparisons to use spf13/cast instead of reflection for numeric, string, and boolean operations
- Simplify Model.Populate internals by eliminating pointer usage and handling comma-separated inputs with early return
- Streamline change stream setup in model_triggers by replacing manual error handling with lo.Must

Tests:
- Expand Populate tests to verify select projections and Category field population
- Add tests to confirm uninvokable triggers return non-nil