### PR TITLE
feat: added type aliases for reflect kinds to provide a single access point

### DIFF
--- a/core/schema_reflect_types.go
+++ b/core/schema_reflect_types.go
@@ -1,0 +1,30 @@
+package elemental
+
+import (
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"reflect"
+)
+
+// Inbuilt types
+
+var Slice = reflect.Slice
+var Map = reflect.Map
+var Struct = reflect.Struct
+var Interface = reflect.Interface
+var Array = reflect.Array
+var Bool = reflect.Bool
+var Int = reflect.Int
+var Int32 = reflect.Int32
+var Int64 = reflect.Int64
+var Uint = reflect.Uint
+var Uint8 = reflect.Uint8
+var Uint16 = reflect.Uint16
+var Uint32 = reflect.Uint32
+var Uint64 = reflect.Uint64
+var Float32 = reflect.Float32
+var Float64 = reflect.Float64
+var String = reflect.String
+
+// Custom types
+
+var ObjectID = reflect.TypeOf(primitive.NilObjectID).Kind()

--- a/core/schema_types.go
+++ b/core/schema_types.go
@@ -17,7 +17,7 @@ type SchemaOptions struct {
 }
 
 type Field struct {
-	Type       reflect.Kind          // Type of the field. Can be any of the reflect.Kind types, or any of the aliases defined in the elemental package such as elemental.ObjectID or a custom reflected type
+	Type       reflect.Kind          // Type of the field. Can be of reflect.Kind, an alias defined within elemental such as elemental.String or a custom reflection
 	Schema     *Schema               // Defines a subschema for the field if it is a subdocument
 	Required   bool                  // Whether the field is required or not when creating a new document
 	Default    any                   // Default value for the field when creating a new document

--- a/core/schema_types.go
+++ b/core/schema_types.go
@@ -17,7 +17,7 @@ type SchemaOptions struct {
 }
 
 type Field struct {
-	Type       reflect.Kind          // Type of the field. Can be any of the reflect.Kind types
+	Type       reflect.Kind          // Type of the field. Can be any of the reflect.Kind types, or any of the aliases defined in the elemental package such as elemental.ObjectID or a custom reflected type
 	Schema     *Schema               // Defines a subschema for the field if it is a subdocument
 	Required   bool                  // Whether the field is required or not when creating a new document
 	Default    any                   // Default value for the field when creating a new document

--- a/tests/core_audit_test.go
+++ b/tests/core_audit_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"reflect"
 	"testing"
 
 	pc "github.com/akalanka47000/go-modkit/parallel_convey"
@@ -19,7 +18,7 @@ func TestCoreAudit(t *testing.T) {
 
 	KingdomModel := elemental.NewModel[Kingdom](entity, elemental.NewSchema(map[string]elemental.Field{
 		"Name": {
-			Type:     reflect.String,
+			Type:     elemental.String,
 			Required: true,
 		},
 	})).SetDatabase(t.Name())

--- a/tests/core_middleware_test.go
+++ b/tests/core_middleware_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"reflect"
 	"testing"
 
 	elemental "github.com/elcengine/elemental/core"
@@ -21,7 +20,7 @@ func TestCoreMiddleware(t *testing.T) {
 
 	CastleModel := elemental.NewModel[Castle]("Castle-For-Middleware", elemental.NewSchema(map[string]elemental.Field{
 		"Name": {
-			Type:     reflect.String,
+			Type:     elemental.String,
 			Required: true,
 		},
 	})).SetDatabase(t.Name())

--- a/tests/core_schema_test.go
+++ b/tests/core_schema_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"fmt"
-	"reflect"
 	"regexp"
 	"testing"
 
@@ -31,7 +30,7 @@ func TestCoreSchemaOptions(t *testing.T) {
 		Convey("Collection should be a plural of the model name if not specified", func() {
 			CastleModel := elemental.NewModel[Castle]("Castle", elemental.NewSchema(map[string]elemental.Field{
 				"Name": {
-					Type:     reflect.String,
+					Type:     elemental.String,
 					Required: true,
 				},
 			})).SetDatabase(t.Name())
@@ -44,7 +43,7 @@ func TestCoreSchemaOptions(t *testing.T) {
 			collectionOptions.SetSizeInBytes(1024)
 			KingdomModel := elemental.NewModel[Kingdom]("Kingdom-Temporary", elemental.NewSchema(map[string]elemental.Field{
 				"Name": {
-					Type:     reflect.String,
+					Type:     elemental.String,
 					Required: true,
 				},
 			}, elemental.SchemaOptions{
@@ -58,7 +57,7 @@ func TestCoreSchemaOptions(t *testing.T) {
 			DATABASE := fmt.Sprintf("%s_%s", t.Name(), "temporary_1")
 			MonsterModel := elemental.NewModel[Monster]("Monster-Temporary", elemental.NewSchema(map[string]elemental.Field{
 				"Name": {
-					Type:     reflect.String,
+					Type:     elemental.String,
 					Required: true,
 				},
 			}, elemental.SchemaOptions{
@@ -79,7 +78,7 @@ func TestCoreSchemaOptions(t *testing.T) {
 			Convey("Required field with default", func() {
 				Model := elemental.NewModel[User](uuid.NewString(), elemental.NewSchema(map[string]elemental.Field{
 					"Name": {
-						Type:     reflect.String,
+						Type:     elemental.String,
 						Required: true,
 						Default:  "Placeholder",
 					},
@@ -94,7 +93,7 @@ func TestCoreSchemaOptions(t *testing.T) {
 			Convey("Min check", func() {
 				Model := elemental.NewModel[User](uuid.NewString(), elemental.NewSchema(map[string]elemental.Field{
 					"Age": {
-						Type: reflect.Int,
+						Type: elemental.Int,
 						Min:  10,
 					},
 				}))
@@ -111,7 +110,7 @@ func TestCoreSchemaOptions(t *testing.T) {
 			Convey("Max check", func() {
 				Model := elemental.NewModel[User](uuid.NewString(), elemental.NewSchema(map[string]elemental.Field{
 					"Age": {
-						Type: reflect.Int,
+						Type: elemental.Int,
 						Max:  120,
 					},
 				}))
@@ -128,7 +127,7 @@ func TestCoreSchemaOptions(t *testing.T) {
 			Convey("Length check", func() {
 				Model := elemental.NewModel[User](uuid.NewString(), elemental.NewSchema(map[string]elemental.Field{
 					"Name": {
-						Type:   reflect.String,
+						Type:   elemental.String,
 						Length: 10,
 					},
 				}))
@@ -142,7 +141,7 @@ func TestCoreSchemaOptions(t *testing.T) {
 			Convey("Regex check", func() {
 				Model := elemental.NewModel[User](uuid.NewString(), elemental.NewSchema(map[string]elemental.Field{
 					"Name": {
-						Type:  reflect.String,
+						Type:  elemental.String,
 						Regex: regexp.MustCompile("^[A-Z]+$"),
 					},
 				}))

--- a/tests/core_triggers_test.go
+++ b/tests/core_triggers_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"context"
-	"reflect"
 	"testing"
 	"time"
 
@@ -20,7 +19,7 @@ func TestCoreTriggers(t *testing.T) {
 
 	CastleModel := elemental.NewModel[Castle]("Castle-For-Triggers", elemental.NewSchema(map[string]elemental.Field{
 		"Name": {
-			Type:     reflect.String,
+			Type:     elemental.String,
 			Required: true,
 		},
 	})).SetDatabase(t.Name())

--- a/tests/fixtures/fixtures.go
+++ b/tests/fixtures/fixtures.go
@@ -2,7 +2,6 @@
 package fixtures
 
 import (
-	"reflect"
 	"time"
 
 	elemental "github.com/elcengine/elemental/core"
@@ -70,23 +69,23 @@ const DefaultUserAge = 18
 
 var UserModel = elemental.NewModel[User]("User", elemental.NewSchema(map[string]elemental.Field{
 	"Name": {
-		Type:     reflect.String,
+		Type:     elemental.String,
 		Required: true,
 		Index:    options.Index().SetUnique(true),
 	},
 	"Age": {
-		Type:    reflect.Int,
+		Type:    elemental.Int,
 		Default: DefaultUserAge,
 	},
 	"Occupation": {
-		Type: reflect.String,
+		Type: elemental.String,
 	},
 	"Weapons": {
-		Type:    reflect.Slice,
+		Type:    elemental.Slice,
 		Default: []string{},
 	},
 	"Retired": {
-		Type:    reflect.Bool,
+		Type:    elemental.Bool,
 		Default: false,
 	},
 }, elemental.SchemaOptions{
@@ -95,30 +94,30 @@ var UserModel = elemental.NewModel[User]("User", elemental.NewSchema(map[string]
 
 var MonsterModel = elemental.NewModel[Monster]("Monster", elemental.NewSchema(map[string]elemental.Field{
 	"Name": {
-		Type:     reflect.String,
+		Type:     elemental.String,
 		Required: true,
 	},
 	"Category": {
-		Type: reflect.String,
+		Type: elemental.String,
 	},
 	"Weaknesses": {
-		Type: reflect.Struct,
+		Type: elemental.Struct,
 		Schema: lo.ToPtr(elemental.NewSchema(map[string]elemental.Field{
 			"Oils": {
-				Type: reflect.Slice,
+				Type: elemental.Slice,
 			},
 			"Signs": {
-				Type:    reflect.Slice,
+				Type:    elemental.Slice,
 				Default: []string{"Igni"},
 			},
 			"Decoctions": {
-				Type: reflect.Slice,
+				Type: elemental.Slice,
 			},
 			"Bombs": {
-				Type: reflect.Slice,
+				Type: elemental.Slice,
 			},
 			"InvulnerableTo": {
-				Type:    reflect.Slice,
+				Type:    elemental.Slice,
 				Default: []string{"Steel"},
 			},
 		})),
@@ -129,7 +128,7 @@ var MonsterModel = elemental.NewModel[Monster]("Monster", elemental.NewSchema(ma
 
 var KingdomModel = elemental.NewModel[Kingdom]("Kingdom", elemental.NewSchema(map[string]elemental.Field{
 	"Name": {
-		Type:     reflect.String,
+		Type:     elemental.String,
 		Required: true,
 	},
 }, elemental.SchemaOptions{
@@ -138,11 +137,11 @@ var KingdomModel = elemental.NewModel[Kingdom]("Kingdom", elemental.NewSchema(ma
 
 var BestiaryModel = elemental.NewModel[Bestiary]("Bestiary", elemental.NewSchema(map[string]elemental.Field{
 	"Monster": {
-		Type: reflect.Struct,
+		Type: elemental.Struct,
 		Ref:  "Monster",
 	},
 	"Kingdom": {
-		Type: reflect.Struct,
+		Type: elemental.ObjectID,
 		Ref:  "Kingdom",
 	},
 }, elemental.SchemaOptions{
@@ -151,7 +150,7 @@ var BestiaryModel = elemental.NewModel[Bestiary]("Bestiary", elemental.NewSchema
 
 var BestiaryWithIDModel = elemental.NewModel[BestiaryWithID]("BestiaryWithID", elemental.NewSchema(map[string]elemental.Field{
 	"MonsterID": {
-		Type:    reflect.String,
+		Type:    elemental.String,
 		Ref:     "Monster",
 		IsRefID: true,
 	},

--- a/tests/fixtures/fixtures.go
+++ b/tests/fixtures/fixtures.go
@@ -141,7 +141,7 @@ var BestiaryModel = elemental.NewModel[Bestiary]("Bestiary", elemental.NewSchema
 		Ref:  "Monster",
 	},
 	"Kingdom": {
-		Type: elemental.ObjectID,
+		Type: elemental.Struct,
 		Ref:  "Kingdom",
 	},
 }, elemental.SchemaOptions{


### PR DESCRIPTION
## Summary by Sourcery

Provide centralized reflect.Kind aliases in the elemental package and migrate all schema Type definitions to use these new aliases instead of direct reflect.Kind references.

New Features:
- Introduce a new `schema_reflect_types.go` file that defines elemental aliases for common reflect.Kinds (e.g., Slice, Map, Struct, Interface, Array, Bool, numeric types, String) and a custom ObjectID alias.

Enhancements:
- Replace all direct `reflect.*` Kind usages in core schema definitions and tests with the corresponding `elemental.*` type aliases to unify type references.