### PR TITLE
Refactor schema type validation and population usage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,8 +57,8 @@ jobs:
           env:
             DEFAULT_DATASOURCE: mongodb://127.0.0.1:27017/elemental?replicaSet=rs0
             SECONDARY_DATASOURCE: mongodb://127.0.0.1:27018/elemental?replicaSet=rs1
-            GOEXPERIMENT: ${{ matrix.go-version == '1.23' && 'aliastypeparams' }}
-            GODEBUG: ${{ matrix.go-version == '1.23' && 'gotypesalias=1' }}
+            GOEXPERIMENT: ${{ matrix.go-version == '1.23' && 'aliastypeparams' || '' }}
+            GODEBUG: ${{ matrix.go-version == '1.23' && 'gotypesalias=1' || '' }}
         
         - name: Upload coverage report
           if: github.event_name == 'pull_request' && github.base_ref == 'main' && matrix.go-version == '1.24' && matrix.mongo-version == '8.0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,7 @@ jobs:
           env:
             DEFAULT_DATASOURCE: mongodb://127.0.0.1:27017/elemental?replicaSet=rs0
             SECONDARY_DATASOURCE: mongodb://127.0.0.1:27018/elemental?replicaSet=rs1
+            GOEXPERIMENT: ${{ matrix.go-version == '1.23' && 'aliastypeparams' || '' }}
         
         - name: Upload coverage report
           if: github.event_name == 'pull_request' && github.base_ref == 'main' && matrix.go-version == '1.24' && matrix.mongo-version == '8.0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,8 @@ jobs:
           env:
             DEFAULT_DATASOURCE: mongodb://127.0.0.1:27017/elemental?replicaSet=rs0
             SECONDARY_DATASOURCE: mongodb://127.0.0.1:27018/elemental?replicaSet=rs1
-            GOEXPERIMENT: ${{ matrix.go-version == '1.23' && 'aliastypeparams' || '' }}
+            GOEXPERIMENT: ${{ matrix.go-version == '1.23' && 'aliastypeparams' }}
+            GODEBUG: ${{ matrix.go-version == '1.23' && 'gotypesalias=1' }}
         
         - name: Upload coverage report
           if: github.event_name == 'pull_request' && github.base_ref == 'main' && matrix.go-version == '1.24' && matrix.mongo-version == '8.0'

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ database
 .elemental
 
 .vscode
+
+.env

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-GO_TEST_ARGS ?= -tags=unit
 GO_BENCH_ARGS ?= -benchtime=30s
 	
 format:

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,6 @@ install:
 	@echo "\033[0;32mGo modules installed successfully.\033[0m"
 tidy:
 	@echo "\033[0;32mRunning go mod tidy...\033[0m"
-	@GOPRIVATE="github.com/clubpay*" go mod tidy -v
+	go mod tidy -v
 	@echo "\033[0;32mVerifying packages...\033[0m"
-	@GOPRIVATE="github.com/clubpay*" go mod verify
+	go mod verify

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ format:
 test:
 	PARALLEL_CONVEY=false make test-lightspeed
 test-lightspeed:
-	go test $(GO_TEST_ARGS) --run=${run} -v --count=1 ./tests/...
+	go test $(GO_TEST_ARGS) --run='${run}' -v --count=1 ./tests/...
 test-coverage:
 	@mkdir -p ./coverage
 	make test GO_TEST_ARGS="--cover -coverpkg=./cmd/...,./core/...,./plugins/...,./utils/... --coverprofile=./coverage/coverage.out"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ format:
 test:
 	PARALLEL_CONVEY=false make test-lightspeed
 test-lightspeed:
-	go test $(GO_TEST_ARGS) -v --count=1 ./tests/...
+	go test $(GO_TEST_ARGS) --run=${run} -v --count=1 ./tests/...
 test-coverage:
 	@mkdir -p ./coverage
 	make test GO_TEST_ARGS="--cover -coverpkg=./cmd/...,./core/...,./plugins/...,./utils/... --coverprofile=./coverage/coverage.out"
@@ -30,9 +30,16 @@ install:
 	go install github.com/evilmartians/lefthook@v1.11.12
 	lefthook install
 	@echo "\033[0;32mLefthook installed and configured successfully.\033[0m"
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
+	@echo "\033[0;32mGolangCI-Lint installed successfully.\033[0m"
 	@which npm > /dev/null && \
 		npm install -g @commitlint/config-conventional@17.6.5 @commitlint/cli@17.6.5 && \
 		echo "\033[0;32mCommitlint installed successfully.\033[0m" || \
 		echo "\033[0;31mNode is not installed. Please install Node.js to use commitlint.\033[0m"
 	go mod tidy
 	@echo "\033[0;32mGo modules installed successfully.\033[0m"
+tidy:
+	@echo "\033[0;32mRunning go mod tidy...\033[0m"
+	@GOPRIVATE="github.com/clubpay*" go mod tidy -v
+	@echo "\033[0;32mVerifying packages...\033[0m"
+	@GOPRIVATE="github.com/clubpay*" go mod verify

--- a/core/model.go
+++ b/core/model.go
@@ -26,6 +26,7 @@ type Model[T any] struct {
 	Cloned              bool   // Indicates if this model has been cloned at least once
 	pipeline            mongo.Pipeline
 	executor            func(m Model[T], ctx context.Context) any
+	result              any // Pointer to the result of the last executed query. This is still not in full use. Only used for operations such as Populate for now.
 	whereField          string
 	failWith            *error
 	orConditionActive   bool

--- a/core/model_actions.go
+++ b/core/model_actions.go
@@ -2,8 +2,6 @@ package elemental
 
 import (
 	"context"
-	"reflect"
-
 	"github.com/elcengine/elemental/utils"
 	"github.com/samber/lo"
 
@@ -31,8 +29,7 @@ func (m Model[T]) Ping(ctx ...context.Context) error {
 
 // Creates or updates the indexes for this model. This method will only create the indexes if they do not exist.
 func (m Model[T]) SyncIndexes(ctx ...context.Context) {
-	var sample [0]T
-	m.Schema.syncIndexes(reflect.TypeOf(sample).Elem(), lo.FromPtr(m.temporaryDatabase), lo.FromPtr(m.temporaryConnection), lo.FromPtr(m.temporaryCollection), ctx...)
+	m.Schema.syncIndexes(m.docReflectType, lo.FromPtr(m.temporaryDatabase), lo.FromPtr(m.temporaryConnection), lo.FromPtr(m.temporaryCollection), ctx...)
 }
 
 // Drops all indexes for this model except the default `_id` index.

--- a/core/model_audit.go
+++ b/core/model_audit.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/elcengine/elemental/utils"
 	"github.com/samber/lo"
+	"github.com/spf13/cast"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -21,6 +22,8 @@ const (
 	AuditTypeUpdate AuditType = "update"
 	AuditTypeDelete AuditType = "delete"
 )
+
+const AuditUserFallback = "System"
 
 type Audit struct {
 	Entity    string      `json:"entity" bson:"entity"`         // The name of the model that was audited.
@@ -64,14 +67,12 @@ func (m Model[T]) EnableAuditing(ctx ...context.Context) {
 		q.Exec(context)
 	}
 
-	userFallback := "System"
-
 	m.OnInsert(func(doc T) {
 		execWithModelOpts(AuditModel.Create(Audit{
 			Entity:    m.Name,
 			Type:      AuditTypeInsert,
 			Document:  utils.CastBSON[bson.M](doc),
-			User:      lo.CoalesceOrEmpty(utils.Cast[string](context.Value(CtxUser)), userFallback),
+			User:      lo.CoalesceOrEmpty(cast.ToString(context.Value(CtxUser)), AuditUserFallback),
 			CreatedAt: time.Now(),
 		}))
 	}, TriggerOptions{Context: &context, Filter: &primitive.M{"ns.coll": primitive.M{"$eq": m.Collection().Name()}}})
@@ -80,7 +81,7 @@ func (m Model[T]) EnableAuditing(ctx ...context.Context) {
 			Entity:    m.Name,
 			Type:      AuditTypeUpdate,
 			Document:  utils.CastBSON[bson.M](doc),
-			User:      lo.CoalesceOrEmpty(utils.Cast[string](context.Value(CtxUser)), userFallback),
+			User:      lo.CoalesceOrEmpty(cast.ToString(context.Value(CtxUser)), AuditUserFallback),
 			CreatedAt: time.Now(),
 		}))
 	}, TriggerOptions{Context: &context, Filter: &primitive.M{"ns.coll": primitive.M{"$eq": m.Collection().Name()}}})
@@ -89,7 +90,7 @@ func (m Model[T]) EnableAuditing(ctx ...context.Context) {
 			Entity:    m.Name,
 			Type:      AuditTypeDelete,
 			Document:  map[string]any{"_id": id},
-			User:      lo.CoalesceOrEmpty(utils.Cast[string](context.Value(CtxUser)), userFallback),
+			User:      lo.CoalesceOrEmpty(cast.ToString(context.Value(CtxUser)), AuditUserFallback),
 			CreatedAt: time.Now(),
 		}))
 	}, TriggerOptions{Context: &context, Filter: &primitive.M{"ns.coll": primitive.M{"$eq": m.Collection().Name()}}})

--- a/core/model_audit.go
+++ b/core/model_audit.go
@@ -2,11 +2,13 @@ package elemental
 
 import (
 	"context"
-	"github.com/elcengine/elemental/utils"
-	"github.com/samber/lo"
 	"reflect"
 	"time"
 
+	"github.com/elcengine/elemental/utils"
+	"github.com/samber/lo"
+
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -68,7 +70,7 @@ func (m Model[T]) EnableAuditing(ctx ...context.Context) {
 		execWithModelOpts(AuditModel.Create(Audit{
 			Entity:    m.Name,
 			Type:      AuditTypeInsert,
-			Document:  *utils.ToBSONDoc(doc),
+			Document:  utils.CastBSON[bson.M](doc),
 			User:      lo.CoalesceOrEmpty(utils.Cast[string](context.Value(CtxUser)), userFallback),
 			CreatedAt: time.Now(),
 		}))
@@ -77,7 +79,7 @@ func (m Model[T]) EnableAuditing(ctx ...context.Context) {
 		execWithModelOpts(AuditModel.Create(Audit{
 			Entity:    m.Name,
 			Type:      AuditTypeUpdate,
-			Document:  *utils.ToBSONDoc(doc),
+			Document:  utils.CastBSON[bson.M](doc),
 			User:      lo.CoalesceOrEmpty(utils.Cast[string](context.Value(CtxUser)), userFallback),
 			CreatedAt: time.Now(),
 		}))

--- a/core/model_populate.go
+++ b/core/model_populate.go
@@ -27,7 +27,11 @@ func (m Model[T]) populate(value any) Model[T] {
 	if path != "" {
 		for i := range m.docReflectType.NumField() {
 			field := m.docReflectType.Field(i)
-			if cleanTag(field.Tag.Get("bson")) == path {
+			tag := cleanTag(field.Tag.Get("bson"))
+			if path == field.Name {
+				path = tag
+			}
+			if path == tag {
 				fieldname = field.Name
 				break
 			}

--- a/core/model_populate.go
+++ b/core/model_populate.go
@@ -1,6 +1,7 @@
 package elemental
 
 import (
+	"context"
 	"reflect"
 	"strings"
 
@@ -84,6 +85,13 @@ func (m Model[T]) Populate(values ...any) Model[T] {
 	}
 	for _, value := range values {
 		m = m.populate(value)
+	}
+	m.executor = func(m Model[T], ctx context.Context) any {
+		var results []bson.M
+		cursor := lo.Must(m.Collection().Aggregate(ctx, m.pipeline))
+		lo.Must0(cursor.All(ctx, &results))
+		m.checkConditionsAndPanic(results)
+		return results
 	}
 	return m
 }

--- a/core/model_populate.go
+++ b/core/model_populate.go
@@ -22,10 +22,8 @@ func (m Model[T]) populate(value any) Model[T] {
 		path = utils.Cast[string](value)
 	}
 	if path != "" {
-		var sample [0]T // Slice of zero length to get the type of T
-		modelType := reflect.TypeOf(sample).Elem()
-		for i := range modelType.NumField() {
-			field := modelType.Field(i)
+		for i := range m.docReflectType.NumField() {
+			field := m.docReflectType.Field(i)
 			if cleanTag(field.Tag.Get("bson")) == path {
 				fieldname = field.Name
 				break

--- a/core/model_query.go
+++ b/core/model_query.go
@@ -134,7 +134,9 @@ func (m Model[T]) ExecSS(ctx ...context.Context) []string {
 }
 
 // ExecInto is a specialized method that executes the query and unmarshals the result into the provided result variable.
-// It is useful when you want to extract results into a custom struct other than the model type such as when you populate certain fields
+// It is useful when you want to extract results into a custom struct other than the model type such as when you populate certain fields.
+//
+// The result variable must be a pointer to your desired type.
 func (m Model[T]) ExecInto(result any, ctx ...context.Context) {
 	rv, bytes := lo.Must2(bson.MarshalValue(m.Exec(ctx...)))
 	bson.UnmarshalValue(rv, bytes, result)

--- a/core/model_query.go
+++ b/core/model_query.go
@@ -7,6 +7,7 @@ import (
 	"github.com/elcengine/elemental/utils"
 	"github.com/samber/lo"
 	"github.com/spf13/cast"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 // Extends the query with a where clause. The value of the clause if specified within this method itself
@@ -130,4 +131,11 @@ func (m Model[T]) ExecInt(ctx ...context.Context) int {
 func (m Model[T]) ExecSS(ctx ...context.Context) []string {
 	result := m.Exec(ctx...)
 	return cast.ToStringSlice(result)
+}
+
+// ExecInto is a specialized method that executes the query and unmarshals the result into the provided result variable.
+// It is useful when you want to extract results into a custom struct other than the model type such as when you populate certain fields
+func (m Model[T]) ExecInto(result any, ctx ...context.Context) {
+	rv, bytes := lo.Must2(bson.MarshalValue(m.Exec(ctx...)))
+	bson.UnmarshalValue(rv, bytes, result)
 }

--- a/core/model_query.go
+++ b/core/model_query.go
@@ -138,6 +138,11 @@ func (m Model[T]) ExecSS(ctx ...context.Context) []string {
 //
 // The result variable must be a pointer to your desired type.
 func (m Model[T]) ExecInto(result any, ctx ...context.Context) {
-	rv, bytes := lo.Must2(bson.MarshalValue(m.Exec(ctx...)))
-	bson.UnmarshalValue(rv, bytes, result)
+	if m.result != nil { // Gradually will migrate everything to use this approach since the block below this is expensive to use.
+		m.result = result
+		m.Exec(ctx...)
+	} else {
+		rv, bytes := lo.Must2(bson.MarshalValue(m.Exec(ctx...)))
+		bson.UnmarshalValue(rv, bytes, result)
+	}
 }

--- a/core/model_query_delete.go
+++ b/core/model_query_delete.go
@@ -25,7 +25,7 @@ func (m Model[T]) FindOneAndDelete(query ...primitive.M) Model[T] {
 			var doc T
 			m.middleware.pre.findOneAndDelete.run(&q)
 			result := m.Collection().FindOneAndDelete(ctx, q)
-			m.checkConditionsAndPanicForSingleResult(result)
+			m.checkConditionsAndPanic(result)
 			lo.Must0(result.Decode(&doc))
 			m.middleware.post.findOneAndDelete.run(&doc)
 			return doc

--- a/core/model_query_delete.go
+++ b/core/model_query_delete.go
@@ -23,11 +23,11 @@ func (m Model[T]) FindOneAndDelete(query ...primitive.M) Model[T] {
 	} else {
 		m.executor = func(m Model[T], ctx context.Context) any {
 			var doc T
-			m.middleware.pre.findOneAndDelete.run(q)
+			m.middleware.pre.findOneAndDelete.run(&q)
 			result := m.Collection().FindOneAndDelete(ctx, q)
-			m.middleware.post.findOneAndDelete.run(&doc)
 			m.checkConditionsAndPanicForSingleResult(result)
 			lo.Must0(result.Decode(&doc))
+			m.middleware.post.findOneAndDelete.run(&doc)
 			return doc
 		}
 	}
@@ -59,10 +59,10 @@ func (m Model[T]) DeleteOne(query ...primitive.M) Model[T] {
 		m = m.UpdateOne(&q, m.softDeletePayload())
 	} else {
 		m.executor = func(m Model[T], ctx context.Context) any {
-			m.middleware.pre.deleteOne.run(q)
+			m.middleware.pre.deleteOne.run(&q)
 			result, err := m.Collection().DeleteOne(ctx, q)
-			m.middleware.post.deleteOne.run(result, err)
 			m.checkConditionsAndPanicForErr(err)
+			m.middleware.post.deleteOne.run(result, err)
 			return result
 		}
 	}
@@ -110,7 +110,7 @@ func (m Model[T]) DeleteMany(query ...primitive.M) Model[T] {
 		m = m.UpdateMany(&q, m.softDeletePayload())
 	} else {
 		m.executor = func(m Model[T], ctx context.Context) any {
-			m.middleware.pre.deleteMany.run(q)
+			m.middleware.pre.deleteMany.run(&q)
 			result, err := m.Collection().DeleteMany(ctx, q)
 			m.checkConditionsAndPanicForErr(err)
 			m.middleware.post.deleteMany.run(result, err)

--- a/core/model_query_update.go
+++ b/core/model_query_update.go
@@ -22,7 +22,7 @@ func (m Model[T]) FindOneAndUpdate(query *primitive.M, doc any, opts ...*options
 		m.middleware.pre.findOneAndUpdate.run(&filters, &doc)
 		result := m.Collection().FindOneAndUpdate(ctx, filters,
 			primitive.M{"$set": m.parseDocument(doc)}, parseUpdateOptions(m, opts)...)
-		m.checkConditionsAndPanicForSingleResult(result)
+		m.checkConditionsAndPanic(result)
 		lo.Must0(result.Decode(&resultDoc))
 		m.middleware.post.findOneAndUpdate.run(&resultDoc)
 		return resultDoc
@@ -37,7 +37,7 @@ func (m Model[T]) FindByIDAndUpdate(id any, doc any, opts ...*options.FindOneAnd
 		var resultDoc T
 		result := m.Collection().FindOneAndUpdate(ctx, primitive.M{"_id": utils.EnsureObjectID(id)},
 			primitive.M{"$set": m.parseDocument(doc)}, parseUpdateOptions(m, opts)...)
-		m.checkConditionsAndPanicForSingleResult(result)
+		m.checkConditionsAndPanic(result)
 		lo.Must0(result.Decode(&resultDoc))
 		return resultDoc
 	}
@@ -85,7 +85,7 @@ func (m Model[T]) Save(doc T) Model[T] {
 		m.middleware.pre.save.run(&parsedDoc)
 		result := m.Collection().FindOneAndUpdate(ctx, &primitive.M{"_id": parsedDoc["_id"]},
 			primitive.M{"$set": parsedDoc}, options.FindOneAndUpdate().SetUpsert(true))
-		m.checkConditionsAndPanicForSingleResult(result)
+		m.checkConditionsAndPanic(result)
 		lo.Must0(result.Decode(&resultDoc))
 		m.middleware.post.save.run(&resultDoc)
 		return utils.CastBSON[T](resultDoc)
@@ -153,7 +153,7 @@ func (m Model[T]) FindOneAndReplace(query *primitive.M, doc any, opts ...*option
 		maps.Copy(filters, m.findMatchStage())
 		m.middleware.pre.findOneAndReplace.run(&filters, &doc)
 		res := m.Collection().FindOneAndReplace(ctx, filters, m.parseDocument(doc), opts...)
-		m.checkConditionsAndPanicForSingleResult(res)
+		m.checkConditionsAndPanic(res)
 		lo.Must0(res.Decode(&resultDoc))
 		m.middleware.post.findOneAndReplace.run(&resultDoc)
 		return resultDoc
@@ -169,7 +169,7 @@ func (m Model[T]) FindByIDAndReplace(id any, doc any, opts ...*options.FindOneAn
 		var resultDoc T
 		res := m.Collection().FindOneAndReplace(ctx, primitive.M{"_id": utils.EnsureObjectID(id)},
 			m.parseDocument(doc), parseUpdateOptions(m, opts)...)
-		m.checkConditionsAndPanicForSingleResult(res)
+		m.checkConditionsAndPanic(res)
 		lo.Must0(res.Decode(&resultDoc))
 		return resultDoc
 	}

--- a/core/model_utils.go
+++ b/core/model_utils.go
@@ -121,15 +121,12 @@ func (m Model[T]) findMatchStage() bson.M {
 	return bson.M{}
 }
 
-func (m Model[T]) parseDocument(doc any) primitive.M {
+func (m Model[T]) parseDocument(doc any) bson.M {
 	docType := reflect.TypeOf(doc).Kind()
 	if docType == reflect.Ptr {
 		doc = reflect.ValueOf(doc).Elem().Interface()
 	}
-	if docType == reflect.Map {
-		return utils.Cast[primitive.M](doc)
-	}
-	result := *utils.ToBSONDoc(doc)
+	result := utils.CastBSON[bson.M](doc)
 	for k, v := range result {
 		fieldValue := reflect.ValueOf(v)
 		if !fieldValue.IsValid() || fieldValue.IsZero() {
@@ -170,4 +167,10 @@ func (m Model[T]) setUpdateOperator(operator string, doc any) Model[T] {
 		})()
 	}
 	return m
+}
+
+// Computes and stores some expensive operations. Invoked at the time of model creation.
+func (m *Model[T]) preprocess() {
+	var sample [0]T // Slice of zero length to get the type of T
+	m.docReflectType = reflect.TypeOf(sample).Elem()
 }

--- a/core/model_utils.go
+++ b/core/model_utils.go
@@ -129,7 +129,8 @@ func (m Model[T]) parseDocument(doc any) bson.M {
 	if docType == reflect.Ptr {
 		doc = reflect.ValueOf(doc).Elem().Interface()
 	}
-	if docType == reflect.Map {
+	switch doc.(type) {
+	case bson.M, map[string]any:
 		return utils.Cast[bson.M](doc)
 	}
 	result := utils.CastBSON[bson.M](doc)

--- a/core/model_utils.go
+++ b/core/model_utils.go
@@ -129,6 +129,9 @@ func (m Model[T]) parseDocument(doc any) bson.M {
 	if docType == reflect.Ptr {
 		doc = reflect.ValueOf(doc).Elem().Interface()
 	}
+	if docType == reflect.Map {
+		return utils.Cast[bson.M](doc)
+	}
 	result := utils.CastBSON[bson.M](doc)
 	for k, v := range result {
 		fieldValue := reflect.ValueOf(v)

--- a/core/schema_reflect_types.go
+++ b/core/schema_reflect_types.go
@@ -1,8 +1,10 @@
 package elemental
 
 import (
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"reflect"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type FieldType interface {
@@ -21,8 +23,6 @@ var Int = reflect.Int
 var Int32 = reflect.Int32
 var Int64 = reflect.Int64
 var Uint = reflect.Uint
-var Uint8 = reflect.Uint8
-var Uint16 = reflect.Uint16
 var Uint32 = reflect.Uint32
 var Uint64 = reflect.Uint64
 var Float32 = reflect.Float32
@@ -31,4 +31,26 @@ var String = reflect.String
 
 // Custom types
 
+var Time = reflect.TypeOf(time.Time{})
 var ObjectID = reflect.TypeOf(primitive.NilObjectID)
+var ObjectIDSlice = reflect.TypeOf([]primitive.ObjectID{})
+var StringSlice = reflect.TypeOf([]string{})
+var StringMap = reflect.TypeOf(map[string]string{})
+var IntSlice = reflect.TypeOf([]int{})
+var IntMap = reflect.TypeOf(map[string]int{})
+var BoolSlice = reflect.TypeOf([]bool{})
+var BoolMap = reflect.TypeOf(map[string]bool{})
+var Int32Slice = reflect.TypeOf([]int32{})
+var Int32Map = reflect.TypeOf(map[string]int32{})
+var Int64Slice = reflect.TypeOf([]int64{})
+var Int64Map = reflect.TypeOf(map[string]int64{})
+var UintSlice = reflect.TypeOf([]uint{})
+var UintMap = reflect.TypeOf(map[string]uint{})
+var Uint32Slice = reflect.TypeOf([]uint32{})
+var Uint32Map = reflect.TypeOf(map[string]uint32{})
+var Uint64Slice = reflect.TypeOf([]uint64{})
+var Uint64Map = reflect.TypeOf(map[string]uint64{})
+var Float32Slice = reflect.TypeOf([]float32{})
+var Float64Slice = reflect.TypeOf([]float64{})
+var Float32Map = reflect.TypeOf(map[string]float32{})
+var Float64Map = reflect.TypeOf(map[string]float64{})

--- a/core/schema_reflect_types.go
+++ b/core/schema_reflect_types.go
@@ -5,6 +5,10 @@ import (
 	"reflect"
 )
 
+type FieldType interface {
+	String() string
+}
+
 // Inbuilt types
 
 var Slice = reflect.Slice
@@ -27,4 +31,4 @@ var String = reflect.String
 
 // Custom types
 
-var ObjectID = reflect.TypeOf(primitive.NilObjectID).Kind()
+var ObjectID = reflect.TypeOf(primitive.NilObjectID)

--- a/core/schema_types.go
+++ b/core/schema_types.go
@@ -1,7 +1,6 @@
 package elemental
 
 import (
-	"reflect"
 	"regexp"
 
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -17,7 +16,7 @@ type SchemaOptions struct {
 }
 
 type Field struct {
-	Type       reflect.Kind          // Type of the field. Can be of reflect.Kind, an alias defined within elemental such as elemental.String or a custom reflection
+	Type       FieldType             // Type of the field. Can be of reflect.Kind, reflect.Type, an Elemental alias such as elemental.String or a custom reflection
 	Schema     *Schema               // Defines a subschema for the field if it is a subdocument
 	Required   bool                  // Whether the field is required or not when creating a new document
 	Default    any                   // Default value for the field when creating a new document

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,6 +3,10 @@ pre-commit:
   commands:
     format:
       run: make format && git add .
+    lint:
+      run: make lint-fix && git add .
+    tidy:
+      run: make tidy && git add .
 
 commit-msg:
   commands:

--- a/tests/cmd_test.go
+++ b/tests/cmd_test.go
@@ -45,6 +45,9 @@ func TestCmd(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		So(cfg.ConnectionStr, ShouldEqual, mocks.DEFAULT_DATASOURCE)
+
+		cmd.RootCmd.SetArgs([]string{"init", mocks.DEFAULT_DATASOURCE})
+		cmd.Execute() // Should do nothing if the file already exists
 	})
 
 	Convey("Migrations and seeds", t, func() {

--- a/tests/core_create_test.go
+++ b/tests/core_create_test.go
@@ -26,7 +26,7 @@ func TestCoreCreate(t *testing.T) {
 	Convey("Create users", t, func() {
 		Convey("Create a single user", func() {
 			user := UserModel.Create(mocks.Ciri).ExecT()
-			So(user.ID, ShouldNotBeNil)
+			So(user.ID.IsZero(), ShouldBeFalse)
 			So(user.Name, ShouldEqual, mocks.Ciri.Name)
 			So(user.Age, ShouldEqual, fixtures.DefaultUserAge)
 			So(user.CreatedAt.Unix(), ShouldBeBetweenOrEqual, time.Now().Add(-10*time.Second).Unix(), time.Now().Unix())
@@ -35,8 +35,8 @@ func TestCoreCreate(t *testing.T) {
 		Convey("Create many users", func() {
 			users := UserModel.CreateMany(mocks.Users[1:]).ExecTT()
 			So(len(users), ShouldEqual, len(mocks.Users[1:]))
-			So(users[0].ID, ShouldNotBeNil)
-			So(users[1].ID, ShouldNotBeNil)
+			So(users[0].ID.IsZero(), ShouldBeFalse)
+			So(users[1].ID.IsZero(), ShouldBeFalse)
 			So(users[0].Name, ShouldEqual, mocks.Geralt.Name)
 			So(users[1].Name, ShouldEqual, mocks.Eredin.Name)
 			So(users[0].Age, ShouldEqual, mocks.Geralt.Age)
@@ -45,7 +45,7 @@ func TestCoreCreate(t *testing.T) {
 		Convey("Create a single user in a different database", func() {
 			TEMPORARY_DB := fmt.Sprintf("%s_%s", t.Name(), "temporary_1")
 			user := UserModel.Create(mocks.Ciri).SetDatabase(TEMPORARY_DB).ExecT()
-			So(user.ID, ShouldNotBeNil)
+			So(user.ID.IsZero(), ShouldBeFalse)
 			var newUser User
 			elemental.UseDatabase(TEMPORARY_DB).Collection(UserModel.Collection().Name()).FindOne(context.TODO(), primitive.M{"_id": user.ID}).Decode(&newUser)
 			So(newUser.Name, ShouldEqual, mocks.Ciri.Name)
@@ -53,7 +53,7 @@ func TestCoreCreate(t *testing.T) {
 		Convey("Create a single user in a different collection in a different database", func() {
 			TEMPORARY_DB := fmt.Sprintf("%s_%s", t.Name(), "temporary_2")
 			user := UserModel.Create(mocks.Geralt).SetDatabase(TEMPORARY_DB).SetCollection("witchers").ExecT()
-			So(user.ID, ShouldNotBeNil)
+			So(user.ID.IsZero(), ShouldBeFalse)
 			var newUser User
 			elemental.UseDatabase(TEMPORARY_DB).Collection("witchers").FindOne(context.TODO(), primitive.M{"_id": user.ID}).Decode(&newUser)
 			So(newUser.Name, ShouldEqual, mocks.Geralt.Name)
@@ -64,7 +64,7 @@ func TestCoreCreate(t *testing.T) {
 			Name:     "Katakan",
 			Category: "Vampire",
 		}).ExecT()
-		So(monster.ID, ShouldNotBeNil)
+		So(monster.ID.IsZero(), ShouldBeFalse)
 		So(monster.Name, ShouldEqual, "Katakan")
 		So(monster.CreatedAt.Unix(), ShouldBeBetweenOrEqual, time.Now().Add(-10*time.Second).Unix(), time.Now().Unix())
 		So(monster.UpdatedAt.Unix(), ShouldBeBetweenOrEqual, time.Now().Add(-10*time.Second).Unix(), time.Now().Unix())

--- a/tests/core_delete_test.go
+++ b/tests/core_delete_test.go
@@ -53,13 +53,13 @@ func TestCoreDelete(t *testing.T) {
 			So(user.Name, ShouldEqual, mocks.Caranthir.Name)
 
 			So(func() {
-				UserModel.SetConnection(uuid.NewString()).DeleteByID(user.ID).OrFail().Exec()
+				UserModel.SetConnection(uuid.NewString()).FindByIDAndDelete(user.ID).OrFail().Exec()
 			}, ShouldPanicWith, errors.New("no results found matching the given query"))
 
 			Convey("With custom error", func() {
 				err := errors.New("some custom error")
 				So(func() {
-					UserModel.SetConnection(uuid.NewString()).DeleteByID(user.ID).OrFail(err).Exec()
+					UserModel.SetConnection(uuid.NewString()).FindByIDAndDelete(user.ID).OrFail(err).Exec()
 				}, ShouldPanicWith, err)
 			})
 		})

--- a/tests/core_middleware_test.go
+++ b/tests/core_middleware_test.go
@@ -7,6 +7,7 @@ import (
 	ts "github.com/elcengine/elemental/tests/fixtures/setup"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -25,22 +26,22 @@ func TestCoreMiddleware(t *testing.T) {
 		},
 	})).SetDatabase(t.Name())
 
-	CastleModel.PreSave(func(castle Castle) bool {
+	CastleModel.PreSave(func(castle *bson.M) bool {
 		invokedHooks["preSave"] = true
 		return true
 	})
 
-	CastleModel.PostSave(func(castle Castle) bool {
+	CastleModel.PostSave(func(castle *bson.M) bool {
 		invokedHooks["postSave"] = true
 		return true
 	})
 
-	CastleModel.PostSave(func(castle Castle) bool {
+	CastleModel.PostSave(func(castle *bson.M) bool {
 		invokedHooks["postSaveSecond"] = true
 		return false
 	})
 
-	CastleModel.PostSave(func(castle Castle) bool {
+	CastleModel.PostSave(func(castle *bson.M) bool {
 		invokedHooks["postSaveThird"] = true
 		return true
 	})
@@ -55,7 +56,7 @@ func TestCoreMiddleware(t *testing.T) {
 		return true
 	})
 
-	CastleModel.PreDeleteOne(func(filters primitive.M) bool {
+	CastleModel.PreDeleteOne(func(filters *primitive.M) bool {
 		invokedHooks["preDeleteOne"] = true
 		return true
 	})
@@ -65,7 +66,7 @@ func TestCoreMiddleware(t *testing.T) {
 		return true
 	})
 
-	CastleModel.PreDeleteMany(func(filters primitive.M) bool {
+	CastleModel.PreDeleteMany(func(filters *primitive.M) bool {
 		invokedHooks["preDeleteMany"] = true
 		return true
 	})
@@ -75,12 +76,12 @@ func TestCoreMiddleware(t *testing.T) {
 		return true
 	})
 
-	CastleModel.PostFind(func(castle []Castle) bool {
+	CastleModel.PostFind(func(castle *[]Castle) bool {
 		invokedHooks["postFind"] = true
 		return true
 	})
 
-	CastleModel.PreFindOneAndUpdate(func(filter primitive.M) bool {
+	CastleModel.PreFindOneAndUpdate(func(filter *primitive.M, doc any) bool {
 		invokedHooks["preFindOneAndUpdate"] = true
 		return true
 	})
@@ -90,13 +91,18 @@ func TestCoreMiddleware(t *testing.T) {
 		return true
 	})
 
-	CastleModel.PreFindOneAndDelete(func(filters primitive.M) bool {
+	CastleModel.PreFindOneAndDelete(func(filters *primitive.M) bool {
 		invokedHooks["preFindOneAndDelete"] = true
 		return true
 	})
 
 	CastleModel.PostFindOneAndDelete(func(castle *Castle) bool {
 		invokedHooks["postFindOneAndDelete"] = true
+		return true
+	})
+
+	CastleModel.PreFindOneAndReplace(func(castle *primitive.M, doc any) bool {
+		invokedHooks["preFindOneAndReplace"] = true
 		return true
 	})
 
@@ -143,6 +149,9 @@ func TestCoreMiddleware(t *testing.T) {
 		})
 		Convey("FindOneAndDelete", func() {
 			So(invokedHooks["preFindOneAndDelete"], ShouldBeTrue)
+		})
+		Convey("FindOneAndReplace", func() {
+			So(invokedHooks["preFindOneAndReplace"], ShouldBeTrue)
 		})
 	})
 

--- a/tests/core_read_populate_test.go
+++ b/tests/core_read_populate_test.go
@@ -32,7 +32,7 @@ func TestCoreReadPopulate(t *testing.T) {
 			Name:     "Nekker",
 			Category: "Nekker",
 		},
-	}).Exec().([]Monster)
+	}).ExecTT()
 
 	kingdoms := KingdomModel.InsertMany([]Kingdom{
 		{
@@ -44,7 +44,7 @@ func TestCoreReadPopulate(t *testing.T) {
 		{
 			Name: "Skellige",
 		},
-	}).Exec().([]Kingdom)
+	}).ExecTT()
 
 	BestiaryModel.InsertMany([]Bestiary{
 		{
@@ -159,14 +159,14 @@ func TestCoreReadPopulate(t *testing.T) {
 					Type:       elemental.ObjectID,
 					Collection: "kingdoms",
 				},
-			}, elemental.SchemaOptions{
-				Collection: "bestiary",
 			}))
-			var bestiaries []GenericBestiary[Monster, Kingdom]
-			BestiaryModel.Find().Populate("monster", "kingdom").ExecInto(&bestiaries)
-			So(bestiaries, ShouldHaveLength, 3)
-			SoKatakan(bestiaries[0])
-			SoDrowner(bestiaries[1])
+			BestiaryModel.Create(Bestiary{Monster: monsters[0], Kingdom: kingdoms[0]}).Exec()
+			var bestiaries []GenericBestiary[Monster, primitive.ObjectID]
+			BestiaryModel.Find().Populate("monster").ExecInto(&bestiaries)
+			So(bestiaries, ShouldHaveLength, 1)
+			So(bestiaries[0].Monster.Name, ShouldEqual, "Katakan")
+			So(bestiaries[0].Monster.Category, ShouldEqual, "Vampire")
+			So(bestiaries[0].Kingdom, ShouldEqual, kingdoms[0].ID)
 		})
 	})
 }

--- a/tests/core_read_populate_test.go
+++ b/tests/core_read_populate_test.go
@@ -159,14 +159,14 @@ func TestCoreReadPopulate(t *testing.T) {
 					Type:       elemental.ObjectID,
 					Collection: "kingdoms",
 				},
+			}, elemental.SchemaOptions{
+				Collection: "bestiary",
 			}))
-			BestiaryModel.Create(Bestiary{Monster: monsters[0], Kingdom: kingdoms[0]}).Exec()
-			var bestiaries []GenericBestiary[Monster, primitive.ObjectID]
-			BestiaryModel.Find().Populate("monster").ExecInto(&bestiaries)
-			So(bestiaries, ShouldHaveLength, 1)
-			So(bestiaries[0].Monster.Name, ShouldEqual, "Katakan")
-			So(bestiaries[0].Monster.Category, ShouldEqual, "Vampire")
-			So(bestiaries[0].Kingdom, ShouldEqual, kingdoms[0].ID)
+			var bestiaries []DetailedBestiary
+			BestiaryModel.Find().Populate("monster", "kingdom").ExecInto(&bestiaries)
+			So(bestiaries, ShouldHaveLength, 3)
+			SoKatakan(bestiaries[0])
+			SoDrowner(bestiaries[1])
 		})
 	})
 }

--- a/tests/core_read_populate_test.go
+++ b/tests/core_read_populate_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"errors"
 	"testing"
 
 	elemental "github.com/elcengine/elemental/core"
@@ -93,6 +94,12 @@ func TestCoreReadPopulate(t *testing.T) {
 				SoKatakan(bestiaries[0])
 				SoDrowner(bestiaries[1])
 			})
+			Convey("With OrFail", func() {
+				bestiaries := make([]DetailedBestiary, 0)
+				So(func() {
+					BestiaryModel.Find(primitive.M{"monster": uuid.New()}).Populate("monster").Populate("kingdom").OrFail().ExecInto(&bestiaries)
+				}, ShouldPanicWith, errors.New("no results found matching the given query"))
+			})
 		})
 		Convey("Populate with a single call", func() {
 			Convey("With bson field name", func() {
@@ -110,7 +117,7 @@ func TestCoreReadPopulate(t *testing.T) {
 				SoDrowner(bestiaries[1])
 			})
 		})
-		Convey("Populate with a single call (Comma separated string)", func() {
+		Convey("Populate with a single call (Space separated string)", func() {
 			var bestiaries []DetailedBestiary
 			BestiaryModel.Find().Populate("monster kingdom").ExecInto(&bestiaries)
 			So(bestiaries, ShouldHaveLength, 3)

--- a/tests/core_read_populate_test.go
+++ b/tests/core_read_populate_test.go
@@ -61,21 +61,21 @@ func TestCoreReadPopulate(t *testing.T) {
 
 	Convey("Find with populated fields", t, func() {
 		Convey("Populate a with multiple calls", func() {
-			bestiary := BestiaryModel.Find().Populate("monster").Populate("kingdom").ExecTT()
+			bestiary := BestiaryModel.Find().Populate("monster").Populate("kingdom").Exec().([]DetailedBestiary)
 			So(bestiary, ShouldHaveLength, 3)
 			So(bestiary[0].Monster.Name, ShouldEqual, "Katakan")
 			So(bestiary[0].Monster.Category, ShouldEqual, "Vampire")
 			So(bestiary[0].Kingdom.Name, ShouldEqual, "Nilfgaard")
 		})
 		Convey("Populate with a single call", func() {
-			bestiary := BestiaryModel.Find().Populate("monster", "kingdom").ExecTT()
+			bestiary := BestiaryModel.Find().Populate("monster", "kingdom").Exec().([]DetailedBestiary)
 			So(bestiary, ShouldHaveLength, 3)
 			So(bestiary[0].Monster.Name, ShouldEqual, "Katakan")
 			So(bestiary[0].Monster.Category, ShouldEqual, "Vampire")
 			So(bestiary[0].Kingdom.Name, ShouldEqual, "Nilfgaard")
 		})
 		Convey("Populate with a single call (Comma separated string)", func() {
-			bestiary := BestiaryModel.Find().Populate("monster kingdom").ExecTT()
+			bestiary := BestiaryModel.Find().Populate("monster kingdom").Exec().([]DetailedBestiary)
 			So(bestiary, ShouldHaveLength, 3)
 			So(bestiary[0].Monster.Name, ShouldEqual, "Katakan")
 			So(bestiary[0].Monster.Category, ShouldEqual, "Vampire")
@@ -85,7 +85,7 @@ func TestCoreReadPopulate(t *testing.T) {
 			bestiary := BestiaryModel.Find().Populate(primitive.M{
 				"path":   "monster",
 				"select": primitive.M{"name": 1},
-			}, "kingdom").ExecTT()
+			}, "kingdom").Exec().([]DetailedBestiary)
 			So(bestiary, ShouldHaveLength, 3)
 			So(bestiary[0].Monster.Name, ShouldEqual, "Katakan")
 			So(bestiary[0].Monster.Category, ShouldEqual, "")

--- a/tests/core_read_populate_test.go
+++ b/tests/core_read_populate_test.go
@@ -161,7 +161,7 @@ func TestCoreReadPopulate(t *testing.T) {
 				},
 			}, elemental.SchemaOptions{
 				Collection: "bestiary",
-			}))
+			})).SetDatabase(t.Name())
 			var bestiaries []DetailedBestiary
 			BestiaryModel.Find().Populate("monster", "kingdom").ExecInto(&bestiaries)
 			So(bestiaries, ShouldHaveLength, 3)

--- a/tests/core_read_populate_test.go
+++ b/tests/core_read_populate_test.go
@@ -77,19 +77,37 @@ func TestCoreReadPopulate(t *testing.T) {
 	}
 
 	Convey("Find with populated fields", t, func() {
-		Convey("Populate a with multiple calls", func() {
-			bestiaries := make([]DetailedBestiary, 0)
-			BestiaryModel.Find().Populate("monster").Populate("kingdom").ExecInto(&bestiaries)
-			So(bestiaries, ShouldHaveLength, 3)
-			SoKatakan(bestiaries[0])
-			SoDrowner(bestiaries[1])
+		Convey("Populate with multiple calls", func() {
+			Convey("With bson field name", func() {
+				bestiaries := make([]DetailedBestiary, 0)
+				BestiaryModel.Find().Populate("monster").Populate("kingdom").ExecInto(&bestiaries)
+				So(bestiaries, ShouldHaveLength, 3)
+				SoKatakan(bestiaries[0])
+				SoDrowner(bestiaries[1])
+			})
+			Convey("With model field name", func() {
+				bestiaries := make([]DetailedBestiary, 0)
+				BestiaryModel.Find().Populate("Monster").Populate("Kingdom").ExecInto(&bestiaries)
+				So(bestiaries, ShouldHaveLength, 3)
+				SoKatakan(bestiaries[0])
+				SoDrowner(bestiaries[1])
+			})
 		})
 		Convey("Populate with a single call", func() {
-			var bestiaries []DetailedBestiary
-			BestiaryModel.Find().Populate("monster", "kingdom").ExecInto(&bestiaries)
-			So(bestiaries, ShouldHaveLength, 3)
-			SoKatakan(bestiaries[0])
-			SoDrowner(bestiaries[1])
+			Convey("With bson field name", func() {
+				var bestiaries []DetailedBestiary
+				BestiaryModel.Find().Populate("monster", "kingdom").ExecInto(&bestiaries)
+				So(bestiaries, ShouldHaveLength, 3)
+				SoKatakan(bestiaries[0])
+				SoDrowner(bestiaries[1])
+			})
+			Convey("With model field name", func() {
+				var bestiaries []DetailedBestiary
+				BestiaryModel.Find().Populate("Monster", "Kingdom").ExecInto(&bestiaries)
+				So(bestiaries, ShouldHaveLength, 3)
+				SoKatakan(bestiaries[0])
+				SoDrowner(bestiaries[1])
+			})
 		})
 		Convey("Populate with a single call (Comma separated string)", func() {
 			var bestiaries []DetailedBestiary

--- a/tests/core_read_populate_test.go
+++ b/tests/core_read_populate_test.go
@@ -95,5 +95,13 @@ func TestCoreReadPopulate(t *testing.T) {
 			So(bestiaries[0].Monster.Category, ShouldEqual, "")
 			So(bestiaries[0].Kingdom.Name, ShouldEqual, "Nilfgaard")
 		})
+		Convey("Populate just one field", func() {
+			var bestiaries []GenericBestiary[Monster, primitive.ObjectID]
+			BestiaryModel.Find().Populate("monster").ExecInto(&bestiaries)
+			So(bestiaries, ShouldHaveLength, 3)
+			So(bestiaries[0].Monster.Name, ShouldEqual, "Katakan")
+			So(bestiaries[0].Monster.Category, ShouldEqual, "Vampire")
+			So(bestiaries[0].Kingdom, ShouldEqual, kingdoms[0].ID)
+		})
 	})
 }

--- a/tests/core_read_populate_test.go
+++ b/tests/core_read_populate_test.go
@@ -5,6 +5,7 @@ import (
 
 	elemental "github.com/elcengine/elemental/core"
 	ts "github.com/elcengine/elemental/tests/fixtures/setup"
+	"github.com/google/uuid"
 	. "github.com/smartystreets/goconvey/convey"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
@@ -149,7 +150,7 @@ func TestCoreReadPopulate(t *testing.T) {
 			So(bestiaries[0].Kingdom, ShouldEqual, kingdoms[0].ID)
 		})
 		Convey("Populate a model with just collection references", func() {
-			BestiaryModel := elemental.NewModel[Bestiary]("Bestiary", elemental.NewSchema(map[string]elemental.Field{
+			BestiaryModel := elemental.NewModel[Bestiary](uuid.NewString(), elemental.NewSchema(map[string]elemental.Field{
 				"Monster": {
 					Type:       elemental.ObjectID,
 					Collection: "monsters",

--- a/tests/core_read_populate_test.go
+++ b/tests/core_read_populate_test.go
@@ -61,35 +61,39 @@ func TestCoreReadPopulate(t *testing.T) {
 
 	Convey("Find with populated fields", t, func() {
 		Convey("Populate a with multiple calls", func() {
-			bestiary := BestiaryModel.Find().Populate("monster").Populate("kingdom").Exec().([]DetailedBestiary)
-			So(bestiary, ShouldHaveLength, 3)
-			So(bestiary[0].Monster.Name, ShouldEqual, "Katakan")
-			So(bestiary[0].Monster.Category, ShouldEqual, "Vampire")
-			So(bestiary[0].Kingdom.Name, ShouldEqual, "Nilfgaard")
+			bestiaries := make([]DetailedBestiary, 0)
+			BestiaryModel.Find().Populate("monster").Populate("kingdom").ExecInto(&bestiaries)
+			So(bestiaries, ShouldHaveLength, 3)
+			So(bestiaries[0].Monster.Name, ShouldEqual, "Katakan")
+			So(bestiaries[0].Monster.Category, ShouldEqual, "Vampire")
+			So(bestiaries[0].Kingdom.Name, ShouldEqual, "Nilfgaard")
 		})
 		Convey("Populate with a single call", func() {
-			bestiary := BestiaryModel.Find().Populate("monster", "kingdom").Exec().([]DetailedBestiary)
-			So(bestiary, ShouldHaveLength, 3)
-			So(bestiary[0].Monster.Name, ShouldEqual, "Katakan")
-			So(bestiary[0].Monster.Category, ShouldEqual, "Vampire")
-			So(bestiary[0].Kingdom.Name, ShouldEqual, "Nilfgaard")
+			var bestiaries []DetailedBestiary
+			BestiaryModel.Find().Populate("monster", "kingdom").ExecInto(&bestiaries)
+			So(bestiaries, ShouldHaveLength, 3)
+			So(bestiaries[0].Monster.Name, ShouldEqual, "Katakan")
+			So(bestiaries[0].Monster.Category, ShouldEqual, "Vampire")
+			So(bestiaries[0].Kingdom.Name, ShouldEqual, "Nilfgaard")
 		})
 		Convey("Populate with a single call (Comma separated string)", func() {
-			bestiary := BestiaryModel.Find().Populate("monster kingdom").Exec().([]DetailedBestiary)
-			So(bestiary, ShouldHaveLength, 3)
-			So(bestiary[0].Monster.Name, ShouldEqual, "Katakan")
-			So(bestiary[0].Monster.Category, ShouldEqual, "Vampire")
-			So(bestiary[0].Kingdom.Name, ShouldEqual, "Nilfgaard")
+			var bestiaries []DetailedBestiary
+			BestiaryModel.Find().Populate("monster kingdom").ExecInto(&bestiaries)
+			So(bestiaries, ShouldHaveLength, 3)
+			So(bestiaries[0].Monster.Name, ShouldEqual, "Katakan")
+			So(bestiaries[0].Monster.Category, ShouldEqual, "Vampire")
+			So(bestiaries[0].Kingdom.Name, ShouldEqual, "Nilfgaard")
 		})
 		Convey("Populate with select", func() {
-			bestiary := BestiaryModel.Find().Populate(primitive.M{
+			var bestiaries []DetailedBestiary
+			BestiaryModel.Find().Populate(primitive.M{
 				"path":   "monster",
 				"select": primitive.M{"name": 1},
-			}, "kingdom").Exec().([]DetailedBestiary)
-			So(bestiary, ShouldHaveLength, 3)
-			So(bestiary[0].Monster.Name, ShouldEqual, "Katakan")
-			So(bestiary[0].Monster.Category, ShouldEqual, "")
-			So(bestiary[0].Kingdom.Name, ShouldEqual, "Nilfgaard")
+			}, "kingdom").ExecInto(&bestiaries)
+			So(bestiaries, ShouldHaveLength, 3)
+			So(bestiaries[0].Monster.Name, ShouldEqual, "Katakan")
+			So(bestiaries[0].Monster.Category, ShouldEqual, "")
+			So(bestiaries[0].Kingdom.Name, ShouldEqual, "Nilfgaard")
 		})
 	})
 }

--- a/tests/core_read_test.go
+++ b/tests/core_read_test.go
@@ -24,6 +24,11 @@ func TestCoreRead(t *testing.T) {
 			users := UserModel.Find().ExecTT()
 			So(users, ShouldHaveLength, len(mocks.Users))
 		})
+		Convey("Find all users with ExecInto", func() {
+			var users []User
+			UserModel.Find().ExecInto(&users)
+			So(users, ShouldHaveLength, len(mocks.Users))
+		})
 		Convey("Find all with a limit of 2", func() {
 			users := UserModel.Find().Limit(2).ExecTT()
 			So(users, ShouldHaveLength, 2)

--- a/tests/core_schema_test.go
+++ b/tests/core_schema_test.go
@@ -193,5 +193,45 @@ func TestCoreSchemaOptions(t *testing.T) {
 				}, ShouldNotPanic)
 			})
 		})
+		Convey("Should use default values when provided", func() {
+			Convey("Default value of a primitive", func() {
+				Model := elemental.NewModel[User](uuid.NewString(), elemental.NewSchema(map[string]elemental.Field{
+					"Name": {
+						Type: elemental.String,
+					},
+					"Age": {
+						Type:    elemental.Int,
+						Default: 30,
+					},
+				}))
+				user := Model.Create(User{Name: uuid.NewString()}).ExecT()
+				So(user.Age, ShouldEqual, 30)
+			})
+			Convey("Default value of a struct", func() {
+				type UserPreferences struct {
+					Language string `json:"language" bson:"language"`
+					Theme    string `json:"theme" bson:"theme"`
+				}
+				type User struct {
+					Name        string           `json:"name" bson:"name"`
+					Preferences *UserPreferences `json:"preferences" bson:"preferences"`
+				}
+				Model := elemental.NewModel[User](uuid.NewString(), elemental.NewSchema(map[string]elemental.Field{
+					"Name": {
+						Type: elemental.String,
+					},
+					"Preferences": {
+						Type: elemental.Struct,
+						Default: UserPreferences{
+							Language: "en",
+							Theme:    "light",
+						},
+					},
+				}))
+				user := Model.Create(User{Name: uuid.NewString()}).ExecT()
+				So(user.Preferences.Language, ShouldEqual, "en")
+				So(user.Preferences.Theme, ShouldEqual, "light")
+			})
+		})
 	})
 }

--- a/tests/fixtures/fixtures.go
+++ b/tests/fixtures/fixtures.go
@@ -54,16 +54,15 @@ type Monster struct {
 	UpdatedAt  time.Time          `json:"updated_at" bson:"updated_at"`
 }
 
-type Bestiary struct {
+type GenericBestiary[T any, Y any] struct {
 	ID      primitive.ObjectID `json:"_id" bson:"_id"`
-	Monster Monster            `json:"monster" bson:"monster"`
-	Kingdom Kingdom            `json:"kingdom" bson:"kingdom"`
+	Monster T                  `json:"monster" bson:"monster"`
+	Kingdom Y                  `json:"kingdom" bson:"kingdom"`
 }
 
-type BestiaryWithID struct {
-	ID        primitive.ObjectID `json:"_id" bson:"_id"`
-	MonsterID string             `json:"monster_id" bson:"monster_id"`
-}
+type Bestiary = GenericBestiary[any, any]
+
+type DetailedBestiary = GenericBestiary[Monster, Kingdom]
 
 const DefaultUserAge = 18
 
@@ -137,23 +136,13 @@ var KingdomModel = elemental.NewModel[Kingdom]("Kingdom", elemental.NewSchema(ma
 
 var BestiaryModel = elemental.NewModel[Bestiary]("Bestiary", elemental.NewSchema(map[string]elemental.Field{
 	"Monster": {
-		Type: elemental.Struct,
+		Type: elemental.ObjectID,
 		Ref:  "Monster",
 	},
 	"Kingdom": {
-		Type: elemental.Struct,
+		Type: elemental.ObjectID,
 		Ref:  "Kingdom",
 	},
 }, elemental.SchemaOptions{
 	Collection: "bestiary",
-}))
-
-var BestiaryWithIDModel = elemental.NewModel[BestiaryWithID]("BestiaryWithID", elemental.NewSchema(map[string]elemental.Field{
-	"MonsterID": {
-		Type:    elemental.String,
-		Ref:     "Monster",
-		IsRefID: true,
-	},
-}, elemental.SchemaOptions{
-	Collection: "bestiaryWithID",
 }))

--- a/tests/plugin_filter_query_test.go
+++ b/tests/plugin_filter_query_test.go
@@ -272,7 +272,7 @@ func TestPluginFilterQuery(t *testing.T) {
 				Kingdom: kingdom,
 			}).Exec()
 
-			bestiaries := BestiaryModel.QS("include=monster,kingdom").ExecTT()
+			bestiaries := BestiaryModel.QS("include=monster,kingdom").Exec().([]DetailedBestiary)
 			So(bestiaries, ShouldHaveLength, 1)
 			So(bestiaries[0].Monster.Name, ShouldEqual, monster.Name)
 			So(bestiaries[0].Monster.Category, ShouldEqual, monster.Category)

--- a/tests/plugin_filter_query_test.go
+++ b/tests/plugin_filter_query_test.go
@@ -272,7 +272,8 @@ func TestPluginFilterQuery(t *testing.T) {
 				Kingdom: kingdom,
 			}).Exec()
 
-			bestiaries := BestiaryModel.QS("include=monster,kingdom").Exec().([]DetailedBestiary)
+			var bestiaries []DetailedBestiary
+			BestiaryModel.QS("include=monster,kingdom").ExecInto(&bestiaries)
 			So(bestiaries, ShouldHaveLength, 1)
 			So(bestiaries[0].Monster.Name, ShouldEqual, monster.Name)
 			So(bestiaries[0].Monster.Category, ShouldEqual, monster.Category)

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -14,6 +14,8 @@ type Kingdom = fixtures.Kingdom
 
 type Monster = fixtures.Monster
 
+type GenericBestiary[T any, Y any] = fixtures.GenericBestiary[T, Y]
+
 type Bestiary = fixtures.Bestiary
 
 type DetailedBestiary = fixtures.DetailedBestiary

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -16,7 +16,7 @@ type Monster = fixtures.Monster
 
 type Bestiary = fixtures.Bestiary
 
-type BestiaryWithID = fixtures.BestiaryWithID
+type DetailedBestiary = fixtures.DetailedBestiary
 
 type MonsterWeakness = fixtures.MonsterWeakness
 
@@ -29,8 +29,6 @@ var MonsterModel = fixtures.MonsterModel
 var KingdomModel = fixtures.KingdomModel
 
 var BestiaryModel = fixtures.BestiaryModel
-
-var BestiaryWithIDModel = fixtures.BestiaryWithIDModel
 
 // Test helper function to wait for a condition to be true or timeout.
 // It will keep checking the condition every 100 milliseconds until the timeout is reached.

--- a/utils/caster.go
+++ b/utils/caster.go
@@ -40,13 +40,3 @@ func FromBSON[T any](bytes []byte) T {
 	bson.Unmarshal(bytes, &v)
 	return v
 }
-
-// Converts an interface to a bson document
-func ToBSONDoc(v any) (doc *bson.M) {
-	data, err := bson.Marshal(v)
-	if err != nil {
-		return nil
-	}
-	bson.Unmarshal(data, &doc)
-	return doc
-}

--- a/utils/query.go
+++ b/utils/query.go
@@ -14,10 +14,7 @@ func MergedQueryOrDefault(query []primitive.M) primitive.M {
 
 func EnsureObjectID(id any) primitive.ObjectID {
 	if idStr, ok := id.(string); ok {
-		parsed, err := primitive.ObjectIDFromHex(idStr)
-		if err != nil {
-			return primitive.NilObjectID
-		}
+		parsed, _ := primitive.ObjectIDFromHex(idStr)
 		return parsed
 	} else if idRaw, ok := id.(primitive.ObjectID); ok {
 		return idRaw

--- a/utils/struct.go
+++ b/utils/struct.go
@@ -1,17 +1,12 @@
 package utils
 
 import (
-	"reflect"
-
-	"github.com/samber/lo"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"reflect"
 )
 
 func IsEmpty(value any) bool {
 	if value == nil {
-		return true
-	}
-	if lo.IsEmpty(value) {
 		return true
 	}
 	if dt, ok := value.(primitive.DateTime); ok {


### PR DESCRIPTION
## Summary by Sourcery

Refactor core schema validation and data population by unifying BSON casting, enhancing type checking with FieldType aliases, and consolidating middleware and query result handling. Improve Populate with pipeline support and raw BSON execution, update Save to upsert for idempotent creations, and expand model hooks and tests to cover replace operations and default value logic.

New Features:
- Add ExecInto method for executing queries into custom result types
- Add PreFindOneAndReplace and PostFindOneAndReplace middleware hooks
- Support pipelines in Populate for advanced lookup stages

Enhancements:
- Unify schema enforcement with improved type validation, default value handling, and single BSON document return
- Introduce FieldType interface and use reflect.Type aliases for rich schema type definitions
- Consolidate error checking into a single checkConditionsAndPanic method
- Revamp parseDocument to consistently use bson.M and remove legacy BSON utilities
- Cache document reflect.Type on model creation for performance
- Refactor Populate to resolve fields via docReflectType, handle select or pipeline options, and return raw BSON results
- Update Save to use FindOneAndUpdate with upsert instead of direct InsertOne

Build:
- Add golangci-lint installation and commitlint, lint-fix and tidy steps in Makefile and Lefthook
- Adjust test runner invocation in Makefile

CI:
- Enable GOEXPERIMENT and GODEBUG flags in GitHub Actions for Go 1.23 type aliases

Tests:
- Refactor tests to use ExecInto and validate pointer type checks, default values, and new Populate scenarios
- Extend core_schema, core_read_populate, core_middleware, and core_audit tests to cover new behaviors and hooks