### PR TITLE
fix: string slice support in populate

### DIFF
--- a/core/model_populate.go
+++ b/core/model_populate.go
@@ -90,10 +90,18 @@ func (m Model[T]) Populate(values ...any) Model[T] {
 		return m.result
 	}
 	if len(values) == 1 {
-		if str, ok := values[0].(string); ok && (strings.Contains(str, ",") || strings.Contains(str, " ")) {
-			parts := strings.FieldsFunc(str, func(r rune) bool {
-				return r == ',' || r == ' '
-			})
+		var parts []string
+		switch v := values[0].(type) {
+		case []string:
+			parts = v
+		case string:
+			if strings.Contains(v, ",") || strings.Contains(v, " ") {
+				parts = strings.FieldsFunc(v, func(r rune) bool {
+					return r == ',' || r == ' '
+				})
+			}
+		}
+		if len(parts) > 0 {
 			for _, value := range parts {
 				m = m.populate(value)
 			}

--- a/tests/core_read_populate_test.go
+++ b/tests/core_read_populate_test.go
@@ -101,7 +101,7 @@ func TestCoreReadPopulate(t *testing.T) {
 				}, ShouldPanicWith, errors.New("no results found matching the given query"))
 			})
 		})
-		Convey("Populate with a single call", func() {
+		Convey("Populate with a single call (Variadic arguments)", func() {
 			Convey("With bson field name", func() {
 				var bestiaries []DetailedBestiary
 				BestiaryModel.Find().Populate("monster", "kingdom").ExecInto(&bestiaries)
@@ -117,12 +117,55 @@ func TestCoreReadPopulate(t *testing.T) {
 				SoDrowner(bestiaries[1])
 			})
 		})
-		Convey("Populate with a single call (Space separated string)", func() {
-			var bestiaries []DetailedBestiary
-			BestiaryModel.Find().Populate("monster kingdom").ExecInto(&bestiaries)
-			So(bestiaries, ShouldHaveLength, 3)
-			SoKatakan(bestiaries[0])
-			SoDrowner(bestiaries[1])
+		Convey("Populate with a single call (Single argument)", func() {
+			Convey("String slice", func() {
+				Convey("With bson field name", func() {
+					var bestiaries []DetailedBestiary
+					BestiaryModel.Find().Populate([]string{"monster", "kingdom"}).ExecInto(&bestiaries)
+					So(bestiaries, ShouldHaveLength, 3)
+					SoKatakan(bestiaries[0])
+					SoDrowner(bestiaries[1])
+				})
+				Convey("With model field name", func() {
+					var bestiaries []DetailedBestiary
+					BestiaryModel.Find().Populate([]string{"Monster", "Kingdom"}).ExecInto(&bestiaries)
+					So(bestiaries, ShouldHaveLength, 3)
+					SoKatakan(bestiaries[0])
+					SoDrowner(bestiaries[1])
+				})
+			})
+			Convey("Space separated string", func() {
+				Convey("With bson field name", func() {
+					var bestiaries []DetailedBestiary
+					BestiaryModel.Find().Populate("monster kingdom").ExecInto(&bestiaries)
+					So(bestiaries, ShouldHaveLength, 3)
+					SoKatakan(bestiaries[0])
+					SoDrowner(bestiaries[1])
+				})
+				Convey("With model field name", func() {
+					var bestiaries []DetailedBestiary
+					BestiaryModel.Find().Populate("Monster Kingdom").ExecInto(&bestiaries)
+					So(bestiaries, ShouldHaveLength, 3)
+					SoKatakan(bestiaries[0])
+					SoDrowner(bestiaries[1])
+				})
+			})
+			Convey("Comma separated string", func() {
+				Convey("With bson field name", func() {
+					var bestiaries []DetailedBestiary
+					BestiaryModel.Find().Populate("monster, kingdom").ExecInto(&bestiaries)
+					So(bestiaries, ShouldHaveLength, 3)
+					SoKatakan(bestiaries[0])
+					SoDrowner(bestiaries[1])
+				})
+				Convey("With model field name", func() {
+					var bestiaries []DetailedBestiary
+					BestiaryModel.Find().Populate("Monster, Kingdom").ExecInto(&bestiaries)
+					So(bestiaries, ShouldHaveLength, 3)
+					SoKatakan(bestiaries[0])
+					SoDrowner(bestiaries[1])
+				})
+			})
 		})
 		Convey("Populate with select", func() {
 			var bestiaries []DetailedBestiary


### PR DESCRIPTION
## Summary by Sourcery

Enable Model.Populate to accept string slices directly and improve its single-argument parsing, and extend tests to cover various Populate input formats.

Bug Fixes:
- Fix Populate to correctly handle []string inputs instead of ignoring them

Enhancements:
- Support passing a []string directly to Model.Populate for field population
- Refactor single-value handling in Populate to unify slice and string parsing logic

Tests:
- Expand Populate tests to include variadic arguments, string slices, space-separated strings, comma-separated strings, and both BSON and model field name variants